### PR TITLE
feat: MEXC futures API integration

### DIFF
--- a/.hermes/plans/2026-04-09_172324-mexc-futures-integration.md
+++ b/.hermes/plans/2026-04-09_172324-mexc-futures-integration.md
@@ -1,0 +1,460 @@
+# MEXC Futures API Integration Plan
+
+**Author:** Hermes Agent  
+**Date:** 2026-04-09  
+**Status:** Planning  
+**Priority:** Backend First, Then Frontend
+
+---
+
+## 1. Goal
+
+Integrate MEXC exchange futures/contract trading into PuckFinance, following the exact same architecture patterns as existing Binance and Bybit integrations. Users should be able to create MEXC trade accounts, view balances, open/manage/close positions, and see trade history -- all from the existing dashboard UI.
+
+---
+
+## 2. Current Context & Assumptions
+
+### Architecture Summary (from codebase inspection)
+
+**Backend (`puckfinance-backend`):**
+- Express + TypeScript, Prisma ORM with PostgreSQL
+- Package manager: pnpm
+- Pattern: Controller class -> exports `() => { router }` function with `apiKeyMiddleware`
+- Service layer: exported functions, client loaded per-request from DB via `loadXClient(tradeAccountId)`
+- API keys encrypted at rest via `CryptoService.encrypt/decrypt`
+- Caching via `node-cache` (imported from `app.ts`)
+- Logging via custom Winston logger (`utils/Logger.ts`)
+- Existing exchanges:
+  - **Binance** (`binance-api-node` SDK): Full futures -- entry (market), SL/TP, positions, balance, income, trade history, snapshots
+  - **Bybit** (`bybit-api` SDK): Partial futures -- entry, SL, balance (hardcoded env keys, not per-user)
+- Prisma `Provider` enum: currently `BINANCE | BYBIT`
+- Routes registered in `src/routes/index.ts` as `/binance`, `/bybit`
+
+**Frontend (`puckfinance-frontend`):**
+- Next.js 15 App Router, React 19, Tailwind CSS 4, Radix UI
+- `lib/binance.ts` -- API client functions calling backend
+- `lib/trade-accounts.ts` -- CRUD for trade accounts, `Provider` type: `"BINANCE" | "BYBIT" | "OKEX"`
+- Trade account dashboard at `app/trade-accounts/[id]/dashboard/page.tsx` (currently hardcoded to Binance)
+- New account form at `app/trade-accounts/new/page.tsx` with provider dropdown (BINANCE/BYBIT/OKEX)
+- Git remote: `git@github.com:puckfinance/backend.git`, working branch: `feature/analysis-history`
+
+### MEXC Futures API Research Summary
+
+**Base URL:** `https://api.mexc.com`  
+**WebSocket URL:** `wss://contract.mexc.com/edge`
+
+**Authentication (HMAC-SHA256):**
+- Headers required: `ApiKey`, `Request-Time` (ms timestamp string), `Signature`, `Recv-Window` (optional, max 60)
+- Signature = HMAC-SHA256(secretKey, accessKey + timestamp + parameterString)
+- GET/DELETE: sort params alphabetically, join with `&`
+- POST: use raw JSON body string as parameterString
+
+**Key Endpoints:**
+
+| Category | Method | Endpoint | Description |
+|----------|--------|----------|-------------|
+| **Market** | GET | `/api/v1/contract/ping` | Server time |
+| **Market** | GET | `/api/v1/contract/detail` | Contract info (precision, leverage, size) |
+| **Market** | GET | `/api/v1/contract/depth/{symbol}` | Order book |
+| **Market** | GET | `/api/v1/contract/ticker` | 24h ticker data |
+| **Market** | GET | `/api/v1/contract/funding_rate/{symbol}` | Current funding rate |
+| **Market** | GET | `/api/v1/contract/kline/{symbol}` | Candlestick data |
+| **Account** | GET | `/api/v1/private/account/assets` | All account assets |
+| **Account** | GET | `/api/v1/private/account/asset/{currency}` | Single currency asset |
+| **Positions** | GET | `/api/v1/private/position/open_positions` | Open positions |
+| **Positions** | GET | `/api/v1/private/position/history_positions` | Position history |
+| **Orders** | POST | `/api/v1/private/order/submit` | Place order |
+| **Orders** | POST | `/api/v1/private/order/cancel` | Cancel order |
+| **Orders** | GET | `/api/v1/private/order/list/open_orders` | Open orders |
+| **Orders** | GET | `/api/v1/private/order/list/history_orders` | Order history |
+| **Orders** | POST | `/api/v1/private/order/stop_order` | Place SL/TP order |
+| **Leverage** | POST | `/api/v1/private/position/leverage` | Set leverage |
+| **Plan** | POST | `/api/v1/private/plan/order` | Trigger/plan order |
+| **Account** | GET | `/api/v1/private/account/trade_fee` | Trade fee info |
+
+**Rate Limits:** 20 req/2s for account endpoints, varies by endpoint
+
+**Symbol format:** `BTC_USDT` (underscore, not hyphen like Binance's `BTCUSDT`)
+
+**No official Node.js SDK exists** -- we build a lightweight HTTP client using `axios` (already a dependency).
+
+---
+
+## 3. Proposed Approach
+
+Follow the **Binance integration pattern exactly** (per-user encrypted API keys, dynamic client loading, full feature parity). Build a custom MEXC API client since no official Node SDK exists. Use axios for HTTP requests with HMAC-SHA256 signing.
+
+---
+
+## 4. Step-by-Step Plan
+
+### PHASE 1: BACKEND (Branch: `feature/mexc-integration`)
+
+#### Step 1: Prisma Migration -- Add MEXC to Provider Enum
+
+**File:** `prisma/schema.prisma`
+
+```prisma
+enum Provider {
+  BINANCE
+  BYBIT
+  MEXC
+}
+```
+
+Run migration:
+```bash
+dotenv -e .env.local -- npx prisma migrate dev --name add-mexc-provider
+```
+
+#### Step 2: Create MEXC API Client Library
+
+**File:** `src/services/mexc/client.ts` (NEW)
+
+Build a typed HTTP client class that handles:
+- HMAC-SHA256 signature generation
+- Header construction (ApiKey, Request-Time, Signature, Recv-Window)
+- GET/POST/DELETE request methods with automatic signing
+- Response parsing (MEXC wraps in `{ success, code, data, message }`)
+- Error handling with proper TypeScript types
+
+```typescript
+// Core structure:
+interface MexcResponse<T> {
+  success: boolean;
+  code: number;
+  data: T;
+  message?: string;
+}
+
+class MexcClient {
+  private apiKey: string;
+  private secretKey: string;
+  private baseUrl: string;
+
+  constructor(apiKey: string, secretKey: string, testnet?: boolean) { ... }
+  
+  private sign(params: string, timestamp: string): string { ... }
+  private buildHeaders(params: string): object { ... }
+  
+  public get<T>(path: string, params?: object): Promise<T> { ... }
+  public post<T>(path: string, body: object): Promise<T> { ... }
+  public delete<T>(path: string, params?: object): Promise<T> { ... }
+}
+```
+
+#### Step 3: Create MEXC Service (Following Binance Pattern)
+
+**File:** `src/services/mexc/index.ts` (NEW)
+
+Export functions matching the Binance service pattern:
+
+| Function | Maps to MEXC Endpoint | Purpose |
+|----------|----------------------|---------|
+| `loadMexcClient(tradeAccountId)` | N/A (internal) | Load encrypted keys from DB, return MexcClient |
+| `checkConnection(client)` | GET `/api/v1/contract/ping` | Ping test |
+| `getContractInfo(client, symbol)` | GET `/api/v1/contract/detail` | Get symbol precision, contract size, leverage limits |
+| `currentPositions(client, symbol?)` | GET `/api/v1/private/position/open_positions` | Get open positions |
+| `getCurrentBalance(client)` | GET `/api/v1/private/account/assets` | Get account balance (USDT) |
+| `getTradeHistory(client, symbol, limit)` | GET `/api/v1/private/order/list/history_orders` | Get trade history |
+| `getOpenOrders(client, symbol?)` | GET `/api/v1/private/order/list/open_orders` | Get open orders |
+| `entry(params)` | POST `/api/v1/private/order/submit` + leverage + SL/TP | Open position (market entry) |
+| `setStoploss(params)` | POST `/api/v1/private/order/stop_order` | Set/modify stop loss |
+| `closePosition(params)` | POST `/api/v1/private/order/submit` (reduceOnly) | Close position |
+| `setLeverage(client, symbol, leverage)` | POST `/api/v1/private/position/leverage` | Set leverage |
+
+**Entry logic (following Binance pattern):**
+1. Check for existing position (cancel if no position, clear orders)
+2. Get contract info (precision, tick size, quantity step)
+3. Get account balance (USDT available)
+4. Calculate position size based on risk/risk_amount
+5. Set leverage
+6. Submit market order
+7. Place stop-loss order (STOP_MARKET equivalent)
+8. Place take-profit order (TAKE_PROFIT equivalent)
+9. Return result with entry/SL/TP/qty
+
+**Key MEXC differences to handle:**
+- Symbol format: `BTC_USDT` (not `BTCUSDT`)
+- Side values: `1` = OPEN_LONG, `2` = CLOSE_LONG, `3` = OPEN_SHORT, `4` = CLOSE_SHORT (or use the enum)
+- Quantity in contracts (not base currency)
+- Order types: `1` = MARKET, `2` = LIMIT, `3` = STOP, `5` = TAKE_PROFIT
+- SL/TP are placed as separate trigger/plan orders
+
+#### Step 4: Create MEXC Controller (Following Binance Pattern)
+
+**File:** `src/controllers/MexcController.ts` (NEW)
+
+```typescript
+class MexcController {
+  public async entry(req, res, next) { ... }      // POST /entry/:trade_account_id
+  public async balance(req, res, next) { ... }     // GET /balance/:trade_account_id
+  public async balanceAll(req, res, next) { ... }  // GET /balance-v3/:trade_account_id
+  public async income(req, res, next) { ... }      // GET /income/:trade_account_id
+  public async tradeHistory(req, res, next) { ... } // GET /trade-history/:trade_account_id
+  public async currentPosition(req, res, next) { ... } // GET /current-position/:trade_account_id
+  public async openOrders(req, res, next) { ... }  // GET /open-orders/:trade_account_id
+}
+
+export default () => {
+  const controller = new MexcController();
+  const router = Router();
+  router.use(apiKeyMiddleware);
+
+  router.post('/entry/:trade_account_id', controller.entry);
+  router.get('/trade-history/:trade_account_id', controller.tradeHistory);
+  router.get('/current-position/:trade_account_id', controller.currentPosition);
+  router.get('/open-orders/:trade_account_id', controller.openOrders);
+  router.get('/balance/:trade_account_id', controller.balance);
+  router.get('/balance-v3/:trade_account_id', controller.balanceAll);
+  router.get('/income/:trade_account_id', controller.income);
+
+  return router;
+};
+```
+
+Entry schema (same as Binance, with MEXC side mapping):
+```typescript
+const entrySchema = z.object({
+  symbol: z.string(),
+  side: z.enum(['BUY', 'SELL']),
+  price: z.string().optional(),
+  risk: z.any().optional(),
+  risk_amount: z.any().optional(),
+  action: z.enum(['ENTRY', 'EXIT', 'MOVE_STOPLOSS']),
+  takeprofit_price: z.string().optional(),
+  stoploss_price: z.string().optional(),
+});
+```
+
+#### Step 5: Register MEXC Routes
+
+**File:** `src/routes/index.ts`
+
+```typescript
+import MexcController from '../controllers/MexcController';
+// ...
+routes.use('/mexc', MexcController());
+```
+
+#### Step 6: Create MEXC-Specific Interfaces
+
+**File:** `src/interfaces/Mexc.ts` (NEW)
+
+```typescript
+export interface MexcPosition { ... }
+export interface MexcBalance { ... }
+export interface MexcOrder { ... }
+export interface MexcContractInfo { ... }
+export interface MexcEntryParams { ... }
+```
+
+#### Step 7: Environment Configuration
+
+**File:** `.env.example` -- Add comment about MEXC
+
+No special env vars needed since API keys are per-user (stored encrypted in DB like Binance).
+
+---
+
+### PHASE 2: FRONTEND (Branch: `feature/mexc-integration-frontend`)
+
+#### Step 8: Update Provider Type
+
+**File:** `lib/trade-accounts.ts`
+
+```typescript
+export type Provider = "BINANCE" | "BYBIT" | "MEXC";
+```
+
+#### Step 9: Create MEXC API Client Library
+
+**File:** `lib/mexc.ts` (NEW)
+
+Mirror `lib/binance.ts` structure with same function signatures:
+
+```typescript
+export interface MexcPosition { ... }
+export interface MexcBalance { ... }
+export interface MexcOrder { ... }
+export interface MexcIncome { ... }
+export interface MexcTradeHistoryItem { ... }
+
+export async function executeEntry(tradeAccountId, params, accessToken) { ... }
+export async function getBalance(tradeAccountId, accessToken) { ... }
+export async function getIncome(tradeAccountId, accessToken) { ... }
+export async function getTradeHistory(tradeAccountId, symbol, accessToken) { ... }
+export async function getCurrentPosition(tradeAccountId, accessToken) { ... }
+export async function getOpenOrders(tradeAccountId, accessToken) { ... }
+```
+
+All functions call `${NEXT_PUBLIC_API_URL}/api/v1/mexc/...?api_key=munkhjinbnoo`
+
+#### Step 10: Update New Trade Account Form
+
+**File:** `app/trade-accounts/new/page.tsx`
+
+Add MEXC option to provider dropdown:
+```html
+<option value="MEXC">MEXC</option>
+```
+
+#### Step 11: Update Trade Account Dashboard (Provider-Agnostic)
+
+**File:** `app/trade-accounts/[id]/dashboard/page.tsx`
+
+- Detect provider from trade account data
+- Conditionally import and call MEXC or Binance API functions
+- Display MEXC-specific webhook URL when provider is MEXC
+- MEXC balance structure differs from Binance -- map to common display format:
+  - `equity` -> Total Balance
+  - `unrealized` -> Unrealized PnL
+  - `availableBalance` -> Available Balance
+
+#### Step 12: Update Trade History Page
+
+**File:** `app/trade-accounts/[id]/trade-history/page.tsx`
+
+- Detect provider, call correct API
+- Map MEXC response fields to display columns
+
+#### Step 13: Frontend API Routes (Next.js Proxy)
+
+**Files:** `app/api/mexc/*/route.ts` (NEW, mirroring binance API routes)
+
+```
+app/api/mexc/entry/[trade_account_id]/route.ts
+app/api/mexc/balance/[trade_account_id]/route.ts
+app/api/mexc/income/[trade_account_id]/route.ts
+app/api/mexc/current-position/[trade_account_id]/route.ts
+app/api/mexc/open-orders/[trade_account_id]/route.ts
+app/api/mexc/trade-history/[trade_account_id]/route.ts
+```
+
+---
+
+## 5. Files Likely to Change
+
+### Backend (NEW files)
+| File | Purpose |
+|------|---------|
+| `src/services/mexc/client.ts` | MEXC HTTP client with HMAC-SHA256 signing |
+| `src/services/mexc/index.ts` | MEXC service functions (loadMexcClient, entry, balance, etc.) |
+| `src/controllers/MexcController.ts` | Express controller with route definitions |
+| `src/interfaces/Mexc.ts` | TypeScript interfaces for MEXC API types |
+
+### Backend (MODIFIED files)
+| File | Change |
+|------|--------|
+| `prisma/schema.prisma` | Add `MEXC` to Provider enum |
+| `src/routes/index.ts` | Add `routes.use('/mexc', MexcController())` |
+| `.env.example` | Add MEXC notes |
+
+### Frontend (NEW files)
+| File | Purpose |
+|------|---------|
+| `lib/mexc.ts` | MEXC API client functions |
+| `app/api/mexc/entry/[trade_account_id]/route.ts` | Next.js proxy for entry |
+| `app/api/mexc/balance/[trade_account_id]/route.ts` | Next.js proxy for balance |
+| `app/api/mexc/income/[trade_account_id]/route.ts` | Next.js proxy for income |
+| `app/api/mexc/current-position/[trade_account_id]/route.ts` | Next.js proxy for positions |
+| `app/api/mexc/open-orders/[trade_account_id]/route.ts` | Next.js proxy for orders |
+| `app/api/mexc/trade-history/[trade_account_id]/route.ts` | Next.js proxy for history |
+
+### Frontend (MODIFIED files)
+| File | Change |
+|------|--------|
+| `lib/trade-accounts.ts` | Add `"MEXC"` to Provider type |
+| `app/trade-accounts/new/page.tsx` | Add MEXC option to provider dropdown |
+| `app/trade-accounts/[id]/dashboard/page.tsx` | Provider-aware data fetching |
+| `app/trade-accounts/[id]/trade-history/page.tsx` | Provider-aware data fetching |
+| `app/trade-accounts/[id]/page.tsx` | Show MEXC provider label |
+
+---
+
+## 6. Tests & Validation
+
+### Backend
+1. **Unit tests** for MEXC client signature generation (HMAC-SHA256)
+2. **Integration tests** against MEXC testnet (if available) or using mocked responses
+3. **Manual test checklist:**
+   - Create MEXC trade account via API
+   - Verify balance retrieval
+   - Place a market entry with SL/TP
+   - Verify position shows in current-positions
+   - Move stoploss
+   - Close position (EXIT action)
+   - Verify trade history
+   - Verify income/PnL history
+
+### Frontend
+1. Create MEXC trade account from UI
+2. View MEXC dashboard with balance
+3. Execute entry webhook
+4. View open positions
+5. View trade history
+6. Verify webhook URL displays correctly
+
+---
+
+## 7. Risks, Tradeoffs & Open Questions
+
+### Risks
+1. **No MEXC testnet for futures** -- MEXC may not have a futures testnet like Binance. Development testing will need minimum-size real orders or extensive mocking.
+2. **MEXC API symbol format** (`BTC_USDT`) differs from Binance (`BTCUSDT`) and Bybit (`BTCUSDT`). Need careful symbol normalization, especially for webhook calls from TradingView.
+3. **MEXC order side encoding** uses numeric values (1=OPEN_LONG, etc.) vs Binance's string values (BUY/SELL). The controller must map between them.
+4. **API stability** -- MEXC has been updating their API frequently (see update log). Endpoint paths and parameters may change.
+5. **Rate limits** -- MEXC rate limits (20 req/2s for account endpoints) are stricter than Binance. May need request throttling.
+
+### Tradeoffs
+1. **Custom HTTP client vs community SDK** -- No official Node.js SDK exists. Building our own gives us full control but means we maintain it. Alternative: use `ccxt` library which supports MEXC, but it's a heavy dependency and doesn't match our coding style.
+2. **Feature parity** -- Bybit integration is incomplete. MEXC integration should aim for full Binance-level parity from the start.
+
+### Open Questions
+1. Does MEXC have a futures testnet/sandbox for development?
+2. Should we normalize the symbol format across all exchanges (e.g., always `BTC_USDT` internally)?
+3. MEXC funding rate and income history endpoints -- need to verify exact response format for income/commission display.
+4. The `secret` field on TradeAccount model -- is it used? MEXC may need a passphrase (like OKX), though MEXC docs don't mention one.
+5. Should the dashboard page be refactored to a provider-agnostic component rather than conditionally importing per provider?
+
+---
+
+## 8. Git Workflow
+
+### Backend
+```bash
+cd ~/projects/puckfinance/puckfinance-backend
+git checkout main
+git pull origin main
+git checkout -b feature/mexc-integration
+# ... implement steps 1-7 ...
+git push origin feature/mexc-integration
+# Create PR: feature/mexc-integration -> main
+```
+
+### Frontend
+```bash
+cd ~/projects/puckfinance/puckfinance-frontend
+git checkout main
+git pull origin main
+git checkout -b feature/mexc-integration-frontend
+# ... implement steps 8-13 ...
+git push origin feature/mexc-integration-frontend
+# Create PR: feature/mexc-integration-frontend -> main
+```
+
+---
+
+## 9. Implementation Order (Priority)
+
+1. **Prisma migration** (Step 1) -- blocking, quick
+2. **MEXC client library** (Step 2) -- core foundation
+3. **MEXC service** (Step 3) -- business logic
+4. **MEXC controller + routes** (Steps 4-5) -- API endpoints
+5. **Manual API testing** -- verify with curl/Postman
+6. **Frontend lib/mexc.ts** (Step 9) -- API client
+7. **Frontend trade account form** (Step 10) -- MEXC option
+8. **Frontend dashboard** (Steps 11-12) -- provider-aware
+9. **Frontend API proxy routes** (Step 13) -- if needed
+10. **PR creation** -- backend PR first, then frontend PR

--- a/prisma/migrations/20260409103856_add_mexc_provider/migration.sql
+++ b/prisma/migrations/20260409103856_add_mexc_provider/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Provider" ADD VALUE 'MEXC';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,7 @@ enum TradeSide {
 enum Provider {
   BINANCE
   BYBIT
+  MEXC
 }
 
 model MarketAnalysis {

--- a/src/controllers/MexcController.ts
+++ b/src/controllers/MexcController.ts
@@ -1,0 +1,357 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import MexcFunctions from '../services/mexc';
+import { NextFunction } from 'express';
+import { Request } from 'express';
+import { Response } from 'express';
+import apiKeyMiddleware from '../middlewares/apikey';
+import logger from '../utils/Logger';
+
+class MexcController {
+  public async entry(req: Request, res: Response, _next: NextFunction) {
+    try {
+      const entrySchema = z.object({
+        symbol: z.string(),
+        side: z.enum(['BUY', 'SELL']),
+        price: z.string().optional(),
+        risk: z.any().optional(),
+        risk_amount: z.any().optional(),
+        action: z.enum(['ENTRY', 'ENTRY_LIMIT', 'EXIT', 'MOVE_STOPLOSS']),
+        takeprofit_price: z.string().optional(),
+        stoploss_price: z.string().optional(),
+      });
+
+      let { symbol, side, price, risk, risk_amount, action, stoploss_price, takeprofit_price } =
+        await entrySchema.parseAsync(req.body);
+
+      console.log({ symbol, side, price, risk, risk_amount, action, stoploss_price, takeprofit_price });
+
+      // Normalize symbol: BTCUSDT -> BTC_USDT for MEXC
+      symbol = symbol?.split('.')?.[0];
+      if (symbol && !symbol.includes('_')) {
+        // Try to convert BTCUSDT to BTC_USDT
+        const usdtMatch = symbol.match(/^(.+?)(USDT)$/);
+        if (usdtMatch) {
+          symbol = `${usdtMatch[1]}_USDT`;
+        }
+      }
+
+      if (!symbol) throw new Error(`Symbol error ${symbol}`);
+
+      const trade_account_id = req.params.trade_account_id;
+
+      if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+      logger.info(`Processing ${action} for ${symbol} on MEXC account ${trade_account_id}`);
+
+      const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+      // cancel all open orders if there is no open position
+      const positions = await MexcFunctions.currentPositions(client, symbol);
+      if (positions.length === 0) {
+        logger.info(`Cancelling all open orders for ${symbol}`);
+        try {
+          const openOrders = await MexcFunctions.getOpenOrders(client, symbol);
+          for (const order of openOrders) {
+            try {
+              await client.delete('/api/v1/private/order/cancel', { orderId: order.id });
+            } catch (e) {
+              console.error('Failed to cancel order:', e);
+            }
+          }
+        } catch (e) {
+          console.error('Failed to fetch/cancel open orders:', e);
+        }
+      }
+
+      switch (action) {
+        case 'ENTRY': {
+          if (!price) throw new Error('price is empty.');
+
+          if (!stoploss_price) throw new Error('stoploss_price is empty.');
+
+          if (!takeprofit_price) throw new Error('take_profit is empty.');
+
+          if (!risk && !risk_amount) throw new Error('risk and risk_amount is empty.');
+
+          logger.info(
+            `MEXC Entry order for ${symbol}: ${side} at ${price} with SL ${stoploss_price} and TP ${takeprofit_price}`,
+          );
+
+          const result = await MexcFunctions.entry({
+            client,
+            symbol,
+            side: side,
+            entryPrice: parseFloat(price),
+            risk: parseFloat(risk),
+            risk_amount: parseFloat(risk_amount),
+            stoplossPrice: parseFloat(stoploss_price),
+            takeProfitPrice: parseFloat(takeprofit_price),
+          });
+
+          return res.status(200).json(result);
+        }
+        case 'MOVE_STOPLOSS': {
+          if (!stoploss_price) throw new Error('stoploss_price is empty.');
+
+          logger.info(`MEXC Moving stoploss for ${symbol} to ${stoploss_price}`);
+
+          const result = await MexcFunctions.setStoploss({
+            client,
+            symbol,
+            side,
+            price: parseFloat(stoploss_price),
+          });
+
+          return res.status(200).json(result);
+        }
+
+        case 'EXIT': {
+          // Cancel all open orders first
+          logger.info(`MEXC Cancelling all open orders for ${symbol}`);
+          try {
+            const openOrders = await MexcFunctions.getOpenOrders(client, symbol);
+            for (const order of openOrders) {
+              try {
+                await client.delete('/api/v1/private/order/cancel', { orderId: order.id });
+              } catch (e) {
+                console.error('Failed to cancel order:', e);
+              }
+            }
+          } catch (e) {
+            console.error('Failed to cancel open orders:', e);
+          }
+
+          // Fetch fresh position data
+          const currentPositions = await MexcFunctions.currentPositions(client, symbol);
+
+          if (currentPositions.length === 0) {
+            logger.info(`No open position found for ${symbol} after cancelling orders`);
+          } else {
+            const currentPosition = currentPositions[0];
+
+            // type 1=long, 2=short
+            const positionVol = currentPosition.holdVolume;
+            const isLongPosition = currentPosition.type === 1;
+            const originalSideWasLong = side === 'BUY';
+
+            if (positionVol > 0 && isLongPosition === originalSideWasLong) {
+              await client.post('/api/v1/private/order/submit', {
+                symbol: symbol,
+                price: currentPosition.averageOpenPrice,
+                vol: positionVol.toString(),
+                leverage: currentPosition.leverage,
+                side: isLongPosition ? 2 : 4, // 2=close_long, 4=close_short
+                type: 1, // market
+                openType: currentPosition.openType,
+              });
+              logger.info(`MEXC Close order placed for ${symbol}`);
+            } else if (positionVol > 0) {
+              logger.warn(
+                `Position side mismatch for ${symbol}. Current: ${isLongPosition ? 'LONG' : 'SHORT'}, Expected: ${
+                  originalSideWasLong ? 'LONG' : 'SHORT'
+                }. Skipping position close to avoid race condition.`,
+              );
+            }
+          }
+
+          return res.status(200).json({ result: 'Orders cancelled and position checked for safe exit' });
+        }
+      }
+
+      res.json({ success: true });
+    } catch (error: any) {
+      logger.error('Error in MEXC entry endpoint', error);
+      res.status(500).json({ error: error?.message || '' });
+    }
+  }
+
+  public async balance(req: Request, res: Response, _next: NextFunction) {
+    try {
+      const trade_account_id = req.params.trade_account_id;
+
+      if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+      logger.info(`Getting MEXC balance for account ${trade_account_id}`);
+
+      const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+      if (!client) throw new Error('client not found.');
+
+      const result = await MexcFunctions.getCurrentBalance(client);
+
+      res.status(200).json(result);
+    } catch (error: any) {
+      logger.error('Error getting MEXC balance', error);
+      res.status(500).json({ error: error?.message || '' });
+    }
+  }
+
+  public async balanceV3(req: Request, res: Response, _next: NextFunction) {
+    try {
+      const trade_account_id = req.params.trade_account_id;
+
+      if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+      logger.info(`Getting MEXC balance for account ${trade_account_id}`);
+
+      const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+      if (!client) throw new Error('client not found.');
+
+      const result = await MexcFunctions.getCurrentBalanceV3(client);
+
+      res.status(200).json(result);
+    } catch (error: any) {
+      logger.error('Error getting MEXC balance', error);
+      res.status(500).json({ error: error?.message || '' });
+    }
+  }
+
+  public async income(req: Request, res: Response, _next: NextFunction) {
+    try {
+      const trade_account_id = req.params.trade_account_id;
+
+      if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+      logger.info(`Getting MEXC income for account ${trade_account_id}`);
+
+      const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+      if (!client) throw new Error('client not found.');
+
+      const result = await MexcFunctions.getIncome(client, {}, trade_account_id);
+
+      res.json(result);
+    } catch (error: any) {
+      logger.error('Error getting MEXC income', error);
+      res.status(500).json({ error: error?.message || '' });
+    }
+  }
+
+  public async tradeHistory(req: Request, res: Response, _next: NextFunction) {
+    try {
+      let symbol = req.query.symbol as string;
+
+      if (!symbol) throw new Error('symbol is empty.');
+
+      const trade_account_id = req.params.trade_account_id;
+
+      if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+      // Normalize symbol for MEXC
+      if (symbol && !symbol.includes('_')) {
+        const usdtMatch = symbol.match(/^(.+?)(USDT)$/);
+        if (usdtMatch) {
+          symbol = `${usdtMatch[1]}_USDT`;
+        }
+      }
+
+      logger.info(`Getting MEXC trade history for ${symbol} on account ${trade_account_id}`);
+
+      const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+      if (!client) throw new Error('client not found.');
+
+      const result = await MexcFunctions.getTradeHistory(client, symbol, 1000);
+
+      res.json(result);
+    } catch (error: any) {
+      logger.error('Error getting MEXC trade history', error);
+      res.status(500).json({ error: error?.message || '' });
+    }
+  }
+
+  public async currentPosition(req: Request, res: Response, _next: NextFunction) {
+    try {
+      const trade_account_id = req.params.trade_account_id;
+
+      if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+      logger.info(`Getting MEXC current positions on account ${trade_account_id}`);
+
+      const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+      if (!client) throw new Error('client not found.');
+
+      const positions = await MexcFunctions.currentPositions(client);
+      const openOrders = await MexcFunctions.getOpenOrders(client);
+
+      type ExtendedPosition = (typeof positions)[number] & {
+        stoploss: string;
+        takeprofit: string;
+        stoplossAmount: number;
+        takeprofitAmount: number;
+      };
+
+      const extendedPositions: ExtendedPosition[] = positions.map((position) => {
+        const stoploss =
+          openOrders.find(
+            (order) => order.symbol === position.symbol && order.type === 3,
+          )?.triggerPrice || '';
+        const takeprofit =
+          openOrders.find(
+            (order) => order.symbol === position.symbol && order.type === 5,
+          )?.triggerPrice || '';
+
+        const size = position.holdVolume;
+        const entryPrice = parseFloat(position.averageOpenPrice);
+
+        const stoplossAmount = stoploss ? parseFloat(stoploss) * size - entryPrice * size : 0;
+        const takeprofitAmount = takeprofit ? parseFloat(takeprofit) * size - entryPrice * size : 0;
+
+        const extendedPosition: ExtendedPosition = {
+          ...position,
+          stoploss,
+          takeprofit,
+          stoplossAmount,
+          takeprofitAmount,
+        };
+
+        return extendedPosition;
+      });
+
+      res.status(200).json(extendedPositions);
+    } catch (error: any) {
+      logger.error('Error getting MEXC current position', error);
+      res.status(500).json({ error: error?.message || '' });
+    }
+  }
+
+  public async openOrders(req: Request, res: Response, _next: NextFunction) {
+    try {
+      const trade_account_id = req.params.trade_account_id;
+
+      if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+      logger.info(`Getting MEXC open orders for account ${trade_account_id}`);
+
+      const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+      if (!client) throw new Error('client not found.');
+
+      const result = await MexcFunctions.getOpenOrders(client);
+
+      res.status(200).json(result);
+    } catch (error: any) {
+      logger.error('Error getting MEXC open orders', error);
+      res.status(500).json({ error: error?.message || '' });
+    }
+  }
+}
+
+export default () => {
+  const controller = new MexcController();
+  const router = Router();
+  router.use(apiKeyMiddleware);
+
+  router.post('/entry/:trade_account_id', controller.entry);
+  router.get('/trade-history/:trade_account_id', controller.tradeHistory);
+  router.get('/current-position/:trade_account_id', controller.currentPosition);
+  router.get('/open-orders/:trade_account_id', controller.openOrders);
+  router.get('/balance/:trade_account_id', controller.balance);
+  router.get('/balance-v3/:trade_account_id', controller.balanceV3);
+  router.get('/income/:trade_account_id', controller.income);
+
+  return router;
+};

--- a/src/controllers/MexcController.ts
+++ b/src/controllers/MexcController.ts
@@ -8,350 +8,321 @@ import apiKeyMiddleware from '../middlewares/apikey';
 import logger from '../utils/Logger';
 
 class MexcController {
-  public async entry(req: Request, res: Response, _next: NextFunction) {
-    try {
-      const entrySchema = z.object({
-        symbol: z.string(),
-        side: z.enum(['BUY', 'SELL']),
-        price: z.string().optional(),
-        risk: z.any().optional(),
-        risk_amount: z.any().optional(),
-        action: z.enum(['ENTRY', 'ENTRY_LIMIT', 'EXIT', 'MOVE_STOPLOSS']),
-        takeprofit_price: z.string().optional(),
-        stoploss_price: z.string().optional(),
-      });
-
-      let { symbol, side, price, risk, risk_amount, action, stoploss_price, takeprofit_price } =
-        await entrySchema.parseAsync(req.body);
-
-      console.log({ symbol, side, price, risk, risk_amount, action, stoploss_price, takeprofit_price });
-
-      // Normalize symbol: BTCUSDT -> BTC_USDT for MEXC
-      symbol = symbol?.split('.')?.[0];
-      if (symbol && !symbol.includes('_')) {
-        // Try to convert BTCUSDT to BTC_USDT
-        const usdtMatch = symbol.match(/^(.+?)(USDT)$/);
-        if (usdtMatch) {
-          symbol = `${usdtMatch[1]}_USDT`;
-        }
-      }
-
-      if (!symbol) throw new Error(`Symbol error ${symbol}`);
-
-      const trade_account_id = req.params.trade_account_id;
-
-      if (!trade_account_id) throw new Error('trade_account_id is empty.');
-
-      logger.info(`Processing ${action} for ${symbol} on MEXC account ${trade_account_id}`);
-
-      const client = await MexcFunctions.loadMexcClient(trade_account_id);
-
-      // cancel all open orders if there is no open position
-      const positions = await MexcFunctions.currentPositions(client, symbol);
-      if (positions.length === 0) {
-        logger.info(`Cancelling all open orders for ${symbol}`);
+    public async entry(req: Request, res: Response, _next: NextFunction) {
         try {
-          const openOrders = await MexcFunctions.getOpenOrders(client, symbol);
-          for (const order of openOrders) {
+            const entrySchema = z.object({
+                symbol: z.string(),
+                side: z.enum(['BUY', 'SELL']),
+                price: z.string().optional(),
+                risk: z.any().optional(),
+                risk_amount: z.any().optional(),
+                action: z.enum(['ENTRY', 'ENTRY_LIMIT', 'EXIT', 'MOVE_STOPLOSS']),
+                takeprofit_price: z.string().optional(),
+                stoploss_price: z.string().optional(),
+            });
+
+            let { symbol, side, price, risk, risk_amount, action, stoploss_price, takeprofit_price } =
+                await entrySchema.parseAsync(req.body);
+
+            console.log({ symbol, side, price, risk, risk_amount, action, stoploss_price, takeprofit_price });
+
+            symbol = symbol?.split('.')?.[0];
+            if (symbol && !symbol.includes('_')) {
+                const usdtMatch = symbol.match(/^(.+?)(USDT)$/);
+                if (usdtMatch) {
+                    symbol = `${usdtMatch[1]}_USDT`;
+                }
+            }
+
+            if (!symbol) throw new Error(`Symbol error ${symbol}`);
+
+            const trade_account_id = req.params.trade_account_id;
+
+            if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+            logger.info(`Processing ${action} for ${symbol} on MEXC account ${trade_account_id}`);
+
+            const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+            const positions = await MexcFunctions.currentPositions(client, symbol);
+            if (positions.length === 0) {
+                logger.info(`Cancelling all open orders for ${symbol}`);
+                try {
+                    await client.post('/api/v1/private/order/cancel_all', { symbol });
+                } catch (e) {
+                    console.error('Failed to cancel open orders:', e);
+                }
+            }
+
+            switch (action) {
+                case 'ENTRY': {
+                    if (!price) throw new Error('price is empty.');
+
+                    if (!stoploss_price) throw new Error('stoploss_price is empty.');
+
+                    if (!takeprofit_price) throw new Error('take_profit is empty.');
+
+                    if (!risk && !risk_amount) throw new Error('risk and risk_amount is empty.');
+
+                    logger.info(
+                        `MEXC Entry order for ${symbol}: ${side} at ${price} with SL ${stoploss_price} and TP ${takeprofit_price}`,
+                    );
+
+                    const result = await MexcFunctions.entry({
+                        client,
+                        symbol,
+                        side: side,
+                        entryPrice: parseFloat(price),
+                        risk: parseFloat(risk),
+                        risk_amount: parseFloat(risk_amount),
+                        stoplossPrice: parseFloat(stoploss_price),
+                        takeProfitPrice: parseFloat(takeprofit_price),
+                    });
+
+                    return res.status(200).json(result);
+                }
+                case 'MOVE_STOPLOSS': {
+                    if (!stoploss_price) throw new Error('stoploss_price is empty.');
+
+                    logger.info(`MEXC Moving stoploss for ${symbol} to ${stoploss_price}`);
+
+                    const result = await MexcFunctions.setStoploss({
+                        client,
+                        symbol,
+                        side,
+                        price: parseFloat(stoploss_price),
+                    });
+
+                    return res.status(200).json(result);
+                }
+
+                case 'EXIT': {
+                    logger.info(`MEXC Cancelling all open orders for ${symbol}`);
+                    try {
+                        await client.post('/api/v1/private/order/cancel_all', { symbol });
+                    } catch (e) {
+                        console.error('Failed to cancel open orders:', e);
+                    }
+
+                    const currentPositions = await MexcFunctions.currentPositions(client, symbol);
+
+                    if (currentPositions.length === 0) {
+                        logger.info(`No open position found for ${symbol} after cancelling orders`);
+                    } else {
+                        const currentPosition = currentPositions[0];
+
+                        const positionVol = currentPosition.holdVol;
+                        const isLongPosition = currentPosition.positionType === 1;
+                        const originalSideWasLong = side === 'BUY';
+
+                        if (positionVol > 0 && isLongPosition === originalSideWasLong) {
+                            await client.post('/api/v1/private/order/create', {
+                                symbol: symbol,
+                                price: currentPosition.holdAvgPrice.toString(),
+                                vol: positionVol.toString(),
+                                leverage: currentPosition.leverage,
+                                side: isLongPosition ? 4 : 2, // 4=close_long, 2=close_short
+                                type: 5, // market
+                                openType: currentPosition.openType,
+                            });
+                            logger.info(`MEXC Close order placed for ${symbol}`);
+                        } else if (positionVol > 0) {
+                            logger.warn(
+                                `Position side mismatch for ${symbol}. Current: ${isLongPosition ? 'LONG' : 'SHORT'}, Expected: ${
+                                    originalSideWasLong ? 'LONG' : 'SHORT'
+                                }. Skipping position close to avoid race condition.`,
+                            );
+                        }
+                    }
+
+                    return res.status(200).json({ result: 'Orders cancelled and position checked for safe exit' });
+                }
+            }
+
+            res.json({ success: true });
+        } catch (error: any) {
+            logger.error('Error in MEXC entry endpoint', error);
+            res.status(500).json({ error: error?.message || '' });
+        }
+    }
+
+    public async balance(req: Request, res: Response, _next: NextFunction) {
+        try {
+            const trade_account_id = req.params.trade_account_id;
+
+            if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+            logger.info(`Getting MEXC balance for account ${trade_account_id}`);
+
+            const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+            const result = await MexcFunctions.getCurrentBalance(client);
+
+            res.status(200).json(result);
+        } catch (error: any) {
+            logger.error('Error getting MEXC balance', error);
+            res.status(500).json({ error: error?.message || '' });
+        }
+    }
+
+    public async balanceV3(req: Request, res: Response, _next: NextFunction) {
+        try {
+            const trade_account_id = req.params.trade_account_id;
+
+            if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+            logger.info(`Getting MEXC balance for account ${trade_account_id}`);
+
+            const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+            const result = await MexcFunctions.getCurrentBalanceV3(client);
+
+            res.status(200).json(result);
+        } catch (error: any) {
+            logger.error('Error getting MEXC balance', error);
+            res.status(500).json({ error: error?.message || '' });
+        }
+    }
+
+    public async income(req: Request, res: Response, _next: NextFunction) {
+        try {
+            const trade_account_id = req.params.trade_account_id;
+
+            if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+            logger.info(`Getting MEXC income for account ${trade_account_id}`);
+
+            const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+            const result = await MexcFunctions.getIncome(client, {}, trade_account_id);
+
+            res.json(result);
+        } catch (error: any) {
+            logger.error('Error getting MEXC income', error);
+            res.status(500).json({ error: error?.message || '' });
+        }
+    }
+
+    public async tradeHistory(req: Request, res: Response, _next: NextFunction) {
+        try {
+            let symbol = req.query.symbol as string;
+
+            if (!symbol) throw new Error('symbol is empty.');
+
+            const trade_account_id = req.params.trade_account_id;
+
+            if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+            if (symbol && !symbol.includes('_')) {
+                const usdtMatch = symbol.match(/^(.+?)(USDT)$/);
+                if (usdtMatch) {
+                    symbol = `${usdtMatch[1]}_USDT`;
+                }
+            }
+
+            logger.info(`Getting MEXC trade history for ${symbol} on account ${trade_account_id}`);
+
+            const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+            const result = await MexcFunctions.getTradeHistory(client, symbol, 1000);
+
+            res.json(result);
+        } catch (error: any) {
+            logger.error('Error getting MEXC trade history', error);
+            res.status(500).json({ error: error?.message || '' });
+        }
+    }
+
+    public async currentPosition(req: Request, res: Response, _next: NextFunction) {
+        try {
+            const trade_account_id = req.params.trade_account_id;
+
+            if (!trade_account_id) throw new Error('trade_account_id is empty.');
+
+            logger.info(`Getting MEXC current positions on account ${trade_account_id}`);
+
+            const client = await MexcFunctions.loadMexcClient(trade_account_id);
+
+            const positions = await MexcFunctions.currentPositions(client);
+
+            let stopOrders: any[] = [];
             try {
-              await client.delete('/api/v1/private/order/cancel', { orderId: order.id });
+                stopOrders = await MexcFunctions.getStopOrders(client);
             } catch (e) {
-              console.error('Failed to cancel order:', e);
+                console.error('Failed to fetch stop orders:', e);
             }
-          }
-        } catch (e) {
-          console.error('Failed to fetch/cancel open orders:', e);
+
+            type ExtendedPosition = (typeof positions)[number] & {
+                stoploss: string;
+                takeprofit: string;
+                stoplossAmount: number;
+                takeprofitAmount: number;
+            };
+
+            const extendedPositions: ExtendedPosition[] = positions.map((position) => {
+                const stopOrder = stopOrders.find(
+                    (order) => order.symbol === position.symbol && String(order.positionId) === String(position.positionId),
+                );
+
+                const stoploss = stopOrder?.stopLossPrice?.toString() || '';
+                const takeprofit = stopOrder?.takeProfitPrice?.toString() || '';
+
+                const size = position.holdVol;
+                const entryPrice = Number(position.holdAvgPrice);
+
+                const stoplossAmount = stoploss ? Number(stoploss) * size - entryPrice * size : 0;
+                const takeprofitAmount = takeprofit ? Number(takeprofit) * size - entryPrice * size : 0;
+
+                const extendedPosition: ExtendedPosition = {
+                    ...position,
+                    stoploss,
+                    takeprofit,
+                    stoplossAmount,
+                    takeprofitAmount,
+                };
+
+                return extendedPosition;
+            });
+
+            res.status(200).json(extendedPositions);
+        } catch (error: any) {
+            logger.error('Error getting MEXC current position', error);
+            res.status(500).json({ error: error?.message || '' });
         }
-      }
+    }
 
-      switch (action) {
-        case 'ENTRY': {
-          if (!price) throw new Error('price is empty.');
+    public async openOrders(req: Request, res: Response, _next: NextFunction) {
+        try {
+            const trade_account_id = req.params.trade_account_id;
 
-          if (!stoploss_price) throw new Error('stoploss_price is empty.');
+            if (!trade_account_id) throw new Error('trade_account_id is empty.');
 
-          if (!takeprofit_price) throw new Error('take_profit is empty.');
+            logger.info(`Getting MEXC open orders for account ${trade_account_id}`);
 
-          if (!risk && !risk_amount) throw new Error('risk and risk_amount is empty.');
+            const client = await MexcFunctions.loadMexcClient(trade_account_id);
 
-          logger.info(
-            `MEXC Entry order for ${symbol}: ${side} at ${price} with SL ${stoploss_price} and TP ${takeprofit_price}`,
-          );
+            const result = await MexcFunctions.getOpenOrders(client);
 
-          const result = await MexcFunctions.entry({
-            client,
-            symbol,
-            side: side,
-            entryPrice: parseFloat(price),
-            risk: parseFloat(risk),
-            risk_amount: parseFloat(risk_amount),
-            stoplossPrice: parseFloat(stoploss_price),
-            takeProfitPrice: parseFloat(takeprofit_price),
-          });
-
-          return res.status(200).json(result);
+            res.status(200).json(result);
+        } catch (error: any) {
+            logger.error('Error getting MEXC open orders', error);
+            res.status(500).json({ error: error?.message || '' });
         }
-        case 'MOVE_STOPLOSS': {
-          if (!stoploss_price) throw new Error('stoploss_price is empty.');
-
-          logger.info(`MEXC Moving stoploss for ${symbol} to ${stoploss_price}`);
-
-          const result = await MexcFunctions.setStoploss({
-            client,
-            symbol,
-            side,
-            price: parseFloat(stoploss_price),
-          });
-
-          return res.status(200).json(result);
-        }
-
-        case 'EXIT': {
-          // Cancel all open orders first
-          logger.info(`MEXC Cancelling all open orders for ${symbol}`);
-          try {
-            const openOrders = await MexcFunctions.getOpenOrders(client, symbol);
-            for (const order of openOrders) {
-              try {
-                await client.delete('/api/v1/private/order/cancel', { orderId: order.id });
-              } catch (e) {
-                console.error('Failed to cancel order:', e);
-              }
-            }
-          } catch (e) {
-            console.error('Failed to cancel open orders:', e);
-          }
-
-          // Fetch fresh position data
-          const currentPositions = await MexcFunctions.currentPositions(client, symbol);
-
-          if (currentPositions.length === 0) {
-            logger.info(`No open position found for ${symbol} after cancelling orders`);
-          } else {
-            const currentPosition = currentPositions[0];
-
-            // type 1=long, 2=short
-            const positionVol = currentPosition.holdVolume;
-            const isLongPosition = currentPosition.type === 1;
-            const originalSideWasLong = side === 'BUY';
-
-            if (positionVol > 0 && isLongPosition === originalSideWasLong) {
-              await client.post('/api/v1/private/order/submit', {
-                symbol: symbol,
-                price: currentPosition.averageOpenPrice,
-                vol: positionVol.toString(),
-                leverage: currentPosition.leverage,
-                side: isLongPosition ? 2 : 4, // 2=close_long, 4=close_short
-                type: 1, // market
-                openType: currentPosition.openType,
-              });
-              logger.info(`MEXC Close order placed for ${symbol}`);
-            } else if (positionVol > 0) {
-              logger.warn(
-                `Position side mismatch for ${symbol}. Current: ${isLongPosition ? 'LONG' : 'SHORT'}, Expected: ${
-                  originalSideWasLong ? 'LONG' : 'SHORT'
-                }. Skipping position close to avoid race condition.`,
-              );
-            }
-          }
-
-          return res.status(200).json({ result: 'Orders cancelled and position checked for safe exit' });
-        }
-      }
-
-      res.json({ success: true });
-    } catch (error: any) {
-      logger.error('Error in MEXC entry endpoint', error);
-      res.status(500).json({ error: error?.message || '' });
     }
-  }
-
-  public async balance(req: Request, res: Response, _next: NextFunction) {
-    try {
-      const trade_account_id = req.params.trade_account_id;
-
-      if (!trade_account_id) throw new Error('trade_account_id is empty.');
-
-      logger.info(`Getting MEXC balance for account ${trade_account_id}`);
-
-      const client = await MexcFunctions.loadMexcClient(trade_account_id);
-
-      if (!client) throw new Error('client not found.');
-
-      const result = await MexcFunctions.getCurrentBalance(client);
-
-      res.status(200).json(result);
-    } catch (error: any) {
-      logger.error('Error getting MEXC balance', error);
-      res.status(500).json({ error: error?.message || '' });
-    }
-  }
-
-  public async balanceV3(req: Request, res: Response, _next: NextFunction) {
-    try {
-      const trade_account_id = req.params.trade_account_id;
-
-      if (!trade_account_id) throw new Error('trade_account_id is empty.');
-
-      logger.info(`Getting MEXC balance for account ${trade_account_id}`);
-
-      const client = await MexcFunctions.loadMexcClient(trade_account_id);
-
-      if (!client) throw new Error('client not found.');
-
-      const result = await MexcFunctions.getCurrentBalanceV3(client);
-
-      res.status(200).json(result);
-    } catch (error: any) {
-      logger.error('Error getting MEXC balance', error);
-      res.status(500).json({ error: error?.message || '' });
-    }
-  }
-
-  public async income(req: Request, res: Response, _next: NextFunction) {
-    try {
-      const trade_account_id = req.params.trade_account_id;
-
-      if (!trade_account_id) throw new Error('trade_account_id is empty.');
-
-      logger.info(`Getting MEXC income for account ${trade_account_id}`);
-
-      const client = await MexcFunctions.loadMexcClient(trade_account_id);
-
-      if (!client) throw new Error('client not found.');
-
-      const result = await MexcFunctions.getIncome(client, {}, trade_account_id);
-
-      res.json(result);
-    } catch (error: any) {
-      logger.error('Error getting MEXC income', error);
-      res.status(500).json({ error: error?.message || '' });
-    }
-  }
-
-  public async tradeHistory(req: Request, res: Response, _next: NextFunction) {
-    try {
-      let symbol = req.query.symbol as string;
-
-      if (!symbol) throw new Error('symbol is empty.');
-
-      const trade_account_id = req.params.trade_account_id;
-
-      if (!trade_account_id) throw new Error('trade_account_id is empty.');
-
-      // Normalize symbol for MEXC
-      if (symbol && !symbol.includes('_')) {
-        const usdtMatch = symbol.match(/^(.+?)(USDT)$/);
-        if (usdtMatch) {
-          symbol = `${usdtMatch[1]}_USDT`;
-        }
-      }
-
-      logger.info(`Getting MEXC trade history for ${symbol} on account ${trade_account_id}`);
-
-      const client = await MexcFunctions.loadMexcClient(trade_account_id);
-
-      if (!client) throw new Error('client not found.');
-
-      const result = await MexcFunctions.getTradeHistory(client, symbol, 1000);
-
-      res.json(result);
-    } catch (error: any) {
-      logger.error('Error getting MEXC trade history', error);
-      res.status(500).json({ error: error?.message || '' });
-    }
-  }
-
-  public async currentPosition(req: Request, res: Response, _next: NextFunction) {
-    try {
-      const trade_account_id = req.params.trade_account_id;
-
-      if (!trade_account_id) throw new Error('trade_account_id is empty.');
-
-      logger.info(`Getting MEXC current positions on account ${trade_account_id}`);
-
-      const client = await MexcFunctions.loadMexcClient(trade_account_id);
-
-      if (!client) throw new Error('client not found.');
-
-      const positions = await MexcFunctions.currentPositions(client);
-      const openOrders = await MexcFunctions.getOpenOrders(client);
-
-      type ExtendedPosition = (typeof positions)[number] & {
-        stoploss: string;
-        takeprofit: string;
-        stoplossAmount: number;
-        takeprofitAmount: number;
-      };
-
-      const extendedPositions: ExtendedPosition[] = positions.map((position) => {
-        const stoploss =
-          openOrders.find(
-            (order) => order.symbol === position.symbol && order.type === 3,
-          )?.triggerPrice || '';
-        const takeprofit =
-          openOrders.find(
-            (order) => order.symbol === position.symbol && order.type === 5,
-          )?.triggerPrice || '';
-
-        const size = position.holdVolume;
-        const entryPrice = parseFloat(position.averageOpenPrice);
-
-        const stoplossAmount = stoploss ? parseFloat(stoploss) * size - entryPrice * size : 0;
-        const takeprofitAmount = takeprofit ? parseFloat(takeprofit) * size - entryPrice * size : 0;
-
-        const extendedPosition: ExtendedPosition = {
-          ...position,
-          stoploss,
-          takeprofit,
-          stoplossAmount,
-          takeprofitAmount,
-        };
-
-        return extendedPosition;
-      });
-
-      res.status(200).json(extendedPositions);
-    } catch (error: any) {
-      logger.error('Error getting MEXC current position', error);
-      res.status(500).json({ error: error?.message || '' });
-    }
-  }
-
-  public async openOrders(req: Request, res: Response, _next: NextFunction) {
-    try {
-      const trade_account_id = req.params.trade_account_id;
-
-      if (!trade_account_id) throw new Error('trade_account_id is empty.');
-
-      logger.info(`Getting MEXC open orders for account ${trade_account_id}`);
-
-      const client = await MexcFunctions.loadMexcClient(trade_account_id);
-
-      if (!client) throw new Error('client not found.');
-
-      const result = await MexcFunctions.getOpenOrders(client);
-
-      res.status(200).json(result);
-    } catch (error: any) {
-      logger.error('Error getting MEXC open orders', error);
-      res.status(500).json({ error: error?.message || '' });
-    }
-  }
 }
 
 export default () => {
-  const controller = new MexcController();
-  const router = Router();
-  router.use(apiKeyMiddleware);
+    const controller = new MexcController();
+    const router = Router();
+    router.use(apiKeyMiddleware);
 
-  router.post('/entry/:trade_account_id', controller.entry);
-  router.get('/trade-history/:trade_account_id', controller.tradeHistory);
-  router.get('/current-position/:trade_account_id', controller.currentPosition);
-  router.get('/open-orders/:trade_account_id', controller.openOrders);
-  router.get('/balance/:trade_account_id', controller.balance);
-  router.get('/balance-v3/:trade_account_id', controller.balanceV3);
-  router.get('/income/:trade_account_id', controller.income);
+    router.post('/entry/:trade_account_id', controller.entry);
+    router.get('/trade-history/:trade_account_id', controller.tradeHistory);
+    router.get('/current-position/:trade_account_id', controller.currentPosition);
+    router.get('/open-orders/:trade_account_id', controller.openOrders);
+    router.get('/balance/:trade_account_id', controller.balance);
+    router.get('/balance-v3/:trade_account_id', controller.balanceV3);
+    router.get('/income/:trade_account_id', controller.income);
 
-  return router;
+    return router;
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import UserController from '../controllers/UserController';
 import BinanceController from '../controllers/BinanceController';
 import BybitController from '../controllers/BybitController';
+import MexcController from '../controllers/MexcController';
 import TradeAccountController from '../controllers/TradeAccountController';
 import StrategyController from '../controllers/StrategyController';
 import MarketAnalysisHistoryController from '../controllers/MarketAnalysisHistoryController';
@@ -23,6 +24,7 @@ export default () => {
   routes.use('/users', UserController());
   routes.use('/binance', BinanceController());
   routes.use('/bybit', BybitController());
+  routes.use('/mexc', MexcController());
   routes.use('/trade-accounts', TradeAccountController());
   routes.use('/strategies', StrategyController());
   routes.use('/whale', whaleRoutes);

--- a/src/services/mexc.ts
+++ b/src/services/mexc.ts
@@ -1,0 +1,371 @@
+import { MexcClient, MexcPosition, MexcBalance, MexcOrder, MexcContractInfo, MexcHistoryOrder, MexcHistoryPosition } from './mexc/client';
+import moment from 'moment';
+import { cache } from '../app';
+import prisma from '../infrastructure/prisma';
+import { CryptoService } from '../services/crypto';
+import logger from '../utils/Logger';
+
+export const loadMexcClient = async (tradeAccountId: string): Promise<MexcClient> => {
+  const tradeAccount = await prisma.tradeAccount.findUnique({
+    where: {
+      id: tradeAccountId,
+    },
+  });
+
+  if (!tradeAccount) throw new Error('tradeAccount not found.');
+
+  const apiKey = CryptoService.decrypt(tradeAccount.apiKey);
+  const secretKey = CryptoService.decrypt(tradeAccount.secretKey);
+
+  logger.info('Connecting to MEXC');
+  logger.info(`Environment: ${process.env.NODE_ENV}`);
+
+  return new MexcClient(
+    apiKey,
+    secretKey,
+    process.env.NODE_ENV === 'development',
+  );
+};
+
+export const countDecimals = (num: number) => {
+  if (Math.floor(num) === num) return 0;
+  return num.toString().split('.')[1].length || 0;
+};
+
+export const convertToPrecision = (num: number, precision: number) => {
+  return Math.trunc(num * Math.pow(10, precision)) / Math.pow(10, precision);
+};
+
+const checkConnection = async (client: MexcClient) => {
+  return client.get<{ serverTime: number }>('/api/v1/contract/ping');
+};
+
+interface EntryProps {
+  symbol: string;
+  risk: number;
+  risk_amount: number;
+  entryPrice: number;
+  side: 'BUY' | 'SELL';
+  stoplossPrice: number;
+  takeProfitPrice: number;
+  client: MexcClient;
+}
+
+const getContractInfo = async (client: MexcClient, symbol: string): Promise<MexcContractInfo> => {
+  const cacheKey = `mexc-contract-info-${symbol}`;
+  const cached = cache.get(cacheKey) as MexcContractInfo | undefined;
+  if (cached) return cached;
+
+  const contracts = await client.get<MexcContractInfo[]>('/api/v1/contract/detail', { symbol });
+  const contractInfo: MexcContractInfo = Array.isArray(contracts) ? contracts[0] : (contracts as any);
+
+  cache.set(cacheKey, contractInfo, 60 * 60);
+  return contractInfo;
+};
+
+const currentPositions = async (client: MexcClient, symbol?: string): Promise<MexcPosition[]> => {
+  const positions = await client.get<MexcPosition[]>('/api/v1/private/position/open_positions');
+
+  if (symbol) {
+    return positions.filter((item) => item.symbol === symbol);
+  }
+
+  return positions;
+};
+
+const getCurrentBalance = async (client: MexcClient): Promise<MexcBalance | undefined> => {
+  const assets = await client.get<MexcBalance[]>('/api/v1/private/account/assets');
+  const balance = assets.find((item) => item.currency === (process.env.CURRENCY || 'USDT'));
+  return balance;
+};
+
+const getCurrentBalanceV3 = async (client: MexcClient): Promise<MexcBalance[]> => {
+  const assets = await client.get<MexcBalance[]>('/api/v1/private/account/assets');
+  return assets;
+};
+
+const mapSide = (side: 'BUY' | 'SELL'): number => {
+  return side === 'BUY' ? 1 : 3; // 1=open_long, 3=open_short
+};
+
+const mapCloseSide = (side: 'BUY' | 'SELL'): number => {
+  return side === 'BUY' ? 2 : 4; // 2=close_long, 4=close_short
+};
+
+const entry = async ({
+  symbol,
+  entryPrice,
+  risk,
+  risk_amount,
+  side,
+  stoplossPrice,
+  takeProfitPrice,
+  client,
+}: EntryProps) => {
+  // Get contract info for precision
+  const contractInfo = await getContractInfo(client, symbol);
+  const { priceScale, volScale, contractSize } = contractInfo;
+
+  // Get account balance
+  const balance = await getCurrentBalance(client);
+  if (!balance) throw new Error('balance is undefined.');
+
+  // Check for existing position
+  const positions = await currentPositions(client, symbol);
+  const positionSide = side === 'BUY' ? 1 : 2; // 1=long, 2=short
+  const existingPosition = positions.find((p) => p.type === positionSide);
+
+  if (existingPosition) {
+    console.log('Cancelled opening position');
+    throw new Error('Currently in a trade.');
+  }
+
+  // Calculate position size
+  const availableBalance = parseFloat(balance.availableBalance);
+  const riskAmount = risk_amount || availableBalance * (risk / 100);
+  const contractSizeNum = parseFloat(contractSize);
+  const qty = convertToPrecision(riskAmount / Math.abs(entryPrice - stoplossPrice), volScale);
+
+  // Calculate leverage
+  let setLeverage = Math.ceil(((qty * entryPrice * contractSizeNum) / availableBalance) * 1.1);
+  setLeverage = setLeverage === 0 ? 1 : setLeverage;
+
+  console.log({ riskAmount, setLeverage, qty });
+
+  // Set leverage
+  await client.post('/api/v1/private/position/leverage', {
+    symbol,
+    leverage: setLeverage,
+    openType: 1, // cross
+  });
+
+  console.log({
+    qty,
+    balance: balance.equity,
+    leverage: setLeverage,
+    price: entryPrice,
+    volScale,
+  });
+
+  // Place market entry order
+  const executedEntryOrder = await client.post<MexcOrder>('/api/v1/private/order/submit', {
+    symbol,
+    price: entryPrice.toString(),
+    vol: qty.toString(),
+    leverage: setLeverage,
+    side: mapSide(side),
+    type: 1, // market
+    openType: 1, // cross
+  });
+
+  console.log('ENTRY', { executedEntryOrder });
+
+  const currentQty = parseFloat(executedEntryOrder.vol || qty.toString());
+
+  // Place stop-loss order
+  let executedStoplossOrder: any = null;
+  try {
+    executedStoplossOrder = await client.post<MexcOrder>('/api/v1/private/order/stop_order', {
+      symbol,
+      price: convertToPrecision(stoplossPrice, priceScale).toString(),
+      vol: currentQty.toString(),
+      side: mapCloseSide(side),
+      type: 3, // stop
+      triggerPrice: convertToPrecision(stoplossPrice, priceScale).toString(),
+      triggerType: 1, // deal price
+      executeCycle: 1,
+      executeDirection: side === 'BUY' ? 2 : 1,
+    });
+    console.log('STOPLOSS', { executedStoplossOrder });
+  } catch (error) {
+    console.error('Stop loss failed:', error);
+  }
+
+  // Place take-profit order
+  let executedTakeProfitOrder: any = null;
+  try {
+    executedTakeProfitOrder = await client.post<MexcOrder>('/api/v1/private/order/stop_order', {
+      symbol,
+      price: convertToPrecision(takeProfitPrice, priceScale).toString(),
+      vol: currentQty.toString(),
+      side: mapCloseSide(side),
+      type: 5, // take_profit
+      triggerPrice: convertToPrecision(takeProfitPrice, priceScale).toString(),
+      triggerType: 1, // deal price
+      executeCycle: 1,
+      executeDirection: side === 'BUY' ? 2 : 1,
+    });
+    console.log('TAKEPROFIT', { executedTakeProfitOrder });
+  } catch (error) {
+    console.error('Take profit failed:', error);
+  }
+
+  // If stop loss failed, close position immediately
+  if (!executedStoplossOrder) {
+    await client.post<MexcOrder>('/api/v1/private/order/submit', {
+      symbol,
+      price: entryPrice.toString(),
+      vol: currentQty.toString(),
+      leverage: setLeverage,
+      side: mapCloseSide(side),
+      type: 1, // market
+      openType: 1,
+    });
+  }
+
+  return {
+    success: true,
+    entry: entryPrice,
+    stoploss: stoplossPrice,
+    takeprofit: takeProfitPrice,
+    qty: currentQty,
+  };
+};
+
+const setStoploss = async ({
+  symbol,
+  price,
+  side,
+  client,
+}: {
+  symbol: string;
+  price: number;
+  side: 'BUY' | 'SELL';
+  client: MexcClient;
+}) => {
+  const contractInfo = await getContractInfo(client, symbol);
+  const { priceScale } = contractInfo;
+
+  // Get current position
+  const positionSide = side === 'BUY' ? 1 : 2;
+  const positions = await currentPositions(client, symbol);
+  const currentPosition = positions.find((p) => p.type === positionSide);
+
+  if (!currentPosition) throw new Error('currentPosition is undefined.');
+
+  const currentQty = parseFloat(currentPosition.holdVolume.toString());
+
+  // Cancel existing stop orders for this symbol
+  try {
+    const openOrders = await client.get<MexcOrder[]>('/api/v1/private/order/list/open_orders', { symbol });
+    const stopOrders = openOrders.filter((o) => o.type === 3); // type 3 = stop
+
+    for (const order of stopOrders) {
+      try {
+        await client.delete(`/api/v1/private/order/cancel`, { orderId: order.id });
+      } catch (e) {
+        console.error('Failed to cancel stop order:', e);
+      }
+    }
+  } catch (e) {
+    console.error('Failed to fetch open orders for SL cancel:', e);
+  }
+
+  // Place new stop-loss order
+  try {
+    const executedStopLossOrder = await client.post<MexcOrder>('/api/v1/private/order/stop_order', {
+      symbol,
+      price: convertToPrecision(price, priceScale).toString(),
+      vol: currentQty.toString(),
+      side: mapCloseSide(side),
+      type: 3, // stop
+      triggerPrice: convertToPrecision(price, priceScale).toString(),
+      triggerType: 1,
+      executeCycle: 1,
+      executeDirection: side === 'BUY' ? 2 : 1,
+    });
+
+    console.log('MOVE STOPLOSS');
+    console.log({ executedStopLossOrder });
+    console.log('--------');
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const getPosition = async (symbol: string, client: MexcClient) => {
+  const positions = await currentPositions(client, symbol);
+  return positions[0] || undefined;
+};
+
+const getTradeHistory = async (
+  client: MexcClient,
+  symbol: string,
+  limit: number,
+  startTime?: number,
+  endTime?: number,
+) => {
+  if (!startTime) startTime = moment().subtract(7, 'day').unix() * 1000;
+  if (!endTime) endTime = moment().unix() * 1000;
+
+  const result = await client.get<MexcHistoryOrder[]>('/api/v1/private/order/list/history_orders', {
+    symbol,
+    page_num: 1,
+    page_size: limit,
+    ...(startTime && { start_time: startTime }),
+    ...(endTime && { end_time: endTime }),
+  });
+
+  return result;
+};
+
+const getIncome = async (
+  client: MexcClient,
+  options?: {
+    symbol?: string;
+    startTime?: number;
+    endTime?: number;
+    limit?: number;
+  },
+  cacheId?: string,
+) => {
+  const startTime = options?.startTime || moment().endOf('day').subtract(3, 'month').unix() * 1000;
+  const endTime = options?.endTime || moment().endOf('day').unix() * 1000;
+
+  const cacheKey = [
+    cacheId || 'mexc',
+    'income',
+    options?.symbol || 'all',
+    startTime,
+    endTime,
+  ].join('-');
+
+  const cachedData = cache.get(cacheKey);
+  if (cachedData) return cachedData;
+
+  const result = await client.get<MexcHistoryPosition[]>('/api/v1/private/position/history_positions', {
+    ...(options?.symbol && { symbol: options.symbol }),
+    start_time: startTime,
+    end_time: endTime,
+    page_num: 1,
+    page_size: options?.limit || 100,
+  });
+
+  cache.set(cacheKey, result, 60 * 5);
+  return result;
+};
+
+const getOpenOrders = async (client: MexcClient, symbol?: string) => {
+  const params: Record<string, any> = {};
+  if (symbol) params.symbol = symbol;
+
+  const orders = await client.get<MexcOrder[]>('/api/v1/private/order/list/open_orders', params);
+  return orders;
+};
+
+const MexcFunctions = {
+  checkConnection,
+  currentPositions,
+  entry,
+  getPosition,
+  setStoploss,
+  getCurrentBalance,
+  getCurrentBalanceV3,
+  getTradeHistory,
+  getOpenOrders,
+  getIncome,
+  loadMexcClient,
+  getContractInfo,
+};
+
+export default MexcFunctions;

--- a/src/services/mexc.ts
+++ b/src/services/mexc.ts
@@ -1,4 +1,4 @@
-import { MexcClient, MexcPosition, MexcBalance, MexcOrder, MexcContractInfo, MexcHistoryOrder, MexcHistoryPosition } from './mexc/client';
+import { MexcClient, MexcPosition, MexcBalance, MexcOrder, MexcContractInfo, MexcHistoryPosition } from './mexc/client';
 import moment from 'moment';
 import { cache } from '../app';
 import prisma from '../infrastructure/prisma';
@@ -6,366 +6,372 @@ import { CryptoService } from '../services/crypto';
 import logger from '../utils/Logger';
 
 export const loadMexcClient = async (tradeAccountId: string): Promise<MexcClient> => {
-  const tradeAccount = await prisma.tradeAccount.findUnique({
-    where: {
-      id: tradeAccountId,
-    },
-  });
+    const tradeAccount = await prisma.tradeAccount.findUnique({
+        where: {
+            id: tradeAccountId,
+        },
+    });
 
-  if (!tradeAccount) throw new Error('tradeAccount not found.');
+    if (!tradeAccount) throw new Error('tradeAccount not found.');
 
-  const apiKey = CryptoService.decrypt(tradeAccount.apiKey);
-  const secretKey = CryptoService.decrypt(tradeAccount.secretKey);
+    const apiKey = CryptoService.decrypt(tradeAccount.apiKey);
+    const secretKey = CryptoService.decrypt(tradeAccount.secretKey);
 
-  logger.info('Connecting to MEXC');
-  logger.info(`Environment: ${process.env.NODE_ENV}`);
+    logger.info('Connecting to MEXC');
 
-  return new MexcClient(
-    apiKey,
-    secretKey,
-    process.env.NODE_ENV === 'development',
-  );
+    return new MexcClient(apiKey, secretKey);
 };
 
 export const countDecimals = (num: number) => {
-  if (Math.floor(num) === num) return 0;
-  return num.toString().split('.')[1].length || 0;
+    if (Math.floor(num) === num) return 0;
+    return num.toString().split('.')[1].length || 0;
 };
 
 export const convertToPrecision = (num: number, precision: number) => {
-  return Math.trunc(num * Math.pow(10, precision)) / Math.pow(10, precision);
+    return Math.trunc(num * Math.pow(10, precision)) / Math.pow(10, precision);
 };
 
 const checkConnection = async (client: MexcClient) => {
-  return client.get<{ serverTime: number }>('/api/v1/contract/ping');
+    return client.get<{ serverTime: number }>('/api/v1/contract/ping');
 };
 
 interface EntryProps {
-  symbol: string;
-  risk: number;
-  risk_amount: number;
-  entryPrice: number;
-  side: 'BUY' | 'SELL';
-  stoplossPrice: number;
-  takeProfitPrice: number;
-  client: MexcClient;
+    symbol: string;
+    risk: number;
+    risk_amount: number;
+    entryPrice: number;
+    side: 'BUY' | 'SELL';
+    stoplossPrice: number;
+    takeProfitPrice: number;
+    client: MexcClient;
 }
 
 const getContractInfo = async (client: MexcClient, symbol: string): Promise<MexcContractInfo> => {
-  const cacheKey = `mexc-contract-info-${symbol}`;
-  const cached = cache.get(cacheKey) as MexcContractInfo | undefined;
-  if (cached) return cached;
+    const cacheKey = `mexc-contract-info-${symbol}`;
+    const cached = cache.get(cacheKey) as MexcContractInfo | undefined;
+    if (cached) return cached;
 
-  const contracts = await client.get<MexcContractInfo[]>('/api/v1/contract/detail', { symbol });
-  const contractInfo: MexcContractInfo = Array.isArray(contracts) ? contracts[0] : (contracts as any);
+    const result = await client.get<any>('/api/v1/contract/detail', { symbol });
+    const contractInfo: MexcContractInfo = Array.isArray(result) ? result[0] : result;
 
-  cache.set(cacheKey, contractInfo, 60 * 60);
-  return contractInfo;
+    cache.set(cacheKey, contractInfo, 60 * 60);
+    return contractInfo;
 };
 
 const currentPositions = async (client: MexcClient, symbol?: string): Promise<MexcPosition[]> => {
-  const positions = await client.get<MexcPosition[]>('/api/v1/private/position/open_positions');
+    const params: Record<string, any> = {};
+    if (symbol) params.symbol = symbol;
 
-  if (symbol) {
-    return positions.filter((item) => item.symbol === symbol);
-  }
+    const positions = await client.get<MexcPosition[]>('/api/v1/private/position/open_positions', params);
 
-  return positions;
+    if (symbol) {
+        return positions.filter((item) => item.symbol === symbol);
+    }
+
+    return positions;
 };
 
 const getCurrentBalance = async (client: MexcClient): Promise<MexcBalance | undefined> => {
-  const assets = await client.get<MexcBalance[]>('/api/v1/private/account/assets');
-  const balance = assets.find((item) => item.currency === (process.env.CURRENCY || 'USDT'));
-  return balance;
+    const assets = await client.get<MexcBalance[]>('/api/v1/private/account/assets');
+    const balance = assets.find((item) => item.currency === (process.env.CURRENCY || 'USDT'));
+    return balance;
 };
 
 const getCurrentBalanceV3 = async (client: MexcClient): Promise<MexcBalance[]> => {
-  const assets = await client.get<MexcBalance[]>('/api/v1/private/account/assets');
-  return assets;
+    const assets = await client.get<MexcBalance[]>('/api/v1/private/account/assets');
+    return assets;
 };
 
 const mapSide = (side: 'BUY' | 'SELL'): number => {
-  return side === 'BUY' ? 1 : 3; // 1=open_long, 3=open_short
-};
-
-const mapCloseSide = (side: 'BUY' | 'SELL'): number => {
-  return side === 'BUY' ? 2 : 4; // 2=close_long, 4=close_short
+    return side === 'BUY' ? 1 : 3; // 1=open_long, 3=open_short
 };
 
 const entry = async ({
-  symbol,
-  entryPrice,
-  risk,
-  risk_amount,
-  side,
-  stoplossPrice,
-  takeProfitPrice,
-  client,
+    symbol,
+    entryPrice,
+    risk,
+    risk_amount,
+    side,
+    stoplossPrice,
+    takeProfitPrice,
+    client,
 }: EntryProps) => {
-  // Get contract info for precision
-  const contractInfo = await getContractInfo(client, symbol);
-  const { priceScale, volScale, contractSize } = contractInfo;
+    const contractInfo = await getContractInfo(client, symbol);
+    const { priceScale, volScale, contractSize } = contractInfo;
 
-  // Get account balance
-  const balance = await getCurrentBalance(client);
-  if (!balance) throw new Error('balance is undefined.');
+    const balance = await getCurrentBalance(client);
+    if (!balance) throw new Error('balance is undefined.');
 
-  // Check for existing position
-  const positions = await currentPositions(client, symbol);
-  const positionSide = side === 'BUY' ? 1 : 2; // 1=long, 2=short
-  const existingPosition = positions.find((p) => p.type === positionSide);
+    const positions = await currentPositions(client, symbol);
+    const positionSide = side === 'BUY' ? 1 : 2;
+    const existingPosition = positions.find((p) => p.positionType === positionSide);
 
-  if (existingPosition) {
-    console.log('Cancelled opening position');
-    throw new Error('Currently in a trade.');
-  }
+    if (existingPosition) {
+        console.log('Cancelled opening position');
+        throw new Error('Currently in a trade.');
+    }
 
-  // Calculate position size
-  const availableBalance = parseFloat(balance.availableBalance);
-  const riskAmount = risk_amount || availableBalance * (risk / 100);
-  const contractSizeNum = parseFloat(contractSize);
-  const qty = convertToPrecision(riskAmount / Math.abs(entryPrice - stoplossPrice), volScale);
+    const availableBalance = Number(balance.availableBalance);
+    const riskAmount = risk_amount || availableBalance * (risk / 100);
+    const contractSizeNum = parseFloat(contractSize);
+    const qty = convertToPrecision((riskAmount / Math.abs(entryPrice - stoplossPrice)) / contractSizeNum, volScale);
 
-  // Calculate leverage
-  let setLeverage = Math.ceil(((qty * entryPrice * contractSizeNum) / availableBalance) * 1.1);
-  setLeverage = setLeverage === 0 ? 1 : setLeverage;
+    let setLeverage = Math.ceil(((qty * entryPrice * contractSizeNum) / availableBalance) * 1.1);
+    setLeverage = setLeverage === 0 ? 1 : setLeverage;
 
-  console.log({ riskAmount, setLeverage, qty });
+    console.log({ riskAmount, setLeverage, qty });
 
-  // Set leverage
-  await client.post('/api/v1/private/position/leverage', {
-    symbol,
-    leverage: setLeverage,
-    openType: 1, // cross
-  });
-
-  console.log({
-    qty,
-    balance: balance.equity,
-    leverage: setLeverage,
-    price: entryPrice,
-    volScale,
-  });
-
-  // Place market entry order
-  const executedEntryOrder = await client.post<MexcOrder>('/api/v1/private/order/submit', {
-    symbol,
-    price: entryPrice.toString(),
-    vol: qty.toString(),
-    leverage: setLeverage,
-    side: mapSide(side),
-    type: 1, // market
-    openType: 1, // cross
-  });
-
-  console.log('ENTRY', { executedEntryOrder });
-
-  const currentQty = parseFloat(executedEntryOrder.vol || qty.toString());
-
-  // Place stop-loss order
-  let executedStoplossOrder: any = null;
-  try {
-    executedStoplossOrder = await client.post<MexcOrder>('/api/v1/private/order/stop_order', {
-      symbol,
-      price: convertToPrecision(stoplossPrice, priceScale).toString(),
-      vol: currentQty.toString(),
-      side: mapCloseSide(side),
-      type: 3, // stop
-      triggerPrice: convertToPrecision(stoplossPrice, priceScale).toString(),
-      triggerType: 1, // deal price
-      executeCycle: 1,
-      executeDirection: side === 'BUY' ? 2 : 1,
+    // Set leverage using change_leverage endpoint
+    await client.post('/api/v1/private/position/change_leverage', {
+        symbol,
+        leverage: setLeverage,
+        openType: 2,
+        positionType: side === 'BUY' ? 1 : 2,
     });
-    console.log('STOPLOSS', { executedStoplossOrder });
-  } catch (error) {
-    console.error('Stop loss failed:', error);
-  }
 
-  // Place take-profit order
-  let executedTakeProfitOrder: any = null;
-  try {
-    executedTakeProfitOrder = await client.post<MexcOrder>('/api/v1/private/order/stop_order', {
-      symbol,
-      price: convertToPrecision(takeProfitPrice, priceScale).toString(),
-      vol: currentQty.toString(),
-      side: mapCloseSide(side),
-      type: 5, // take_profit
-      triggerPrice: convertToPrecision(takeProfitPrice, priceScale).toString(),
-      triggerType: 1, // deal price
-      executeCycle: 1,
-      executeDirection: side === 'BUY' ? 2 : 1,
+    console.log({
+        qty,
+        balance: balance.equity,
+        leverage: setLeverage,
+        price: entryPrice,
+        volScale,
     });
-    console.log('TAKEPROFIT', { executedTakeProfitOrder });
-  } catch (error) {
-    console.error('Take profit failed:', error);
-  }
 
-  // If stop loss failed, close position immediately
-  if (!executedStoplossOrder) {
-    await client.post<MexcOrder>('/api/v1/private/order/submit', {
-      symbol,
-      price: entryPrice.toString(),
-      vol: currentQty.toString(),
-      leverage: setLeverage,
-      side: mapCloseSide(side),
-      type: 1, // market
-      openType: 1,
+    // Place market entry order
+    const executedEntryOrder = await client.post<any>('/api/v1/private/order/create', {
+        symbol,
+        price: entryPrice.toString(),
+        vol: qty.toString(),
+        leverage: setLeverage,
+        side: mapSide(side),
+        type: 5, // market
+        openType: 2, // cross
     });
-  }
 
-  return {
-    success: true,
-    entry: entryPrice,
-    stoploss: stoplossPrice,
-    takeprofit: takeProfitPrice,
-    qty: currentQty,
-  };
+    console.log('ENTRY', { executedEntryOrder });
+
+    // Get the newly opened position to retrieve positionId for TP/SL
+    const openPositions = await currentPositions(client, symbol);
+    const targetPositionSide = side === 'BUY' ? 1 : 2;
+    const newPosition = openPositions.find((p) => p.positionType === targetPositionSide);
+
+    if (newPosition) {
+        try {
+            await client.post('/api/v1/private/stoporder/place', {
+                positionId: newPosition.positionId,
+                vol: newPosition.holdVol,
+                lossTrend: 1,
+                profitTrend: 1,
+                stopLossPrice: convertToPrecision(stoplossPrice, priceScale).toString(),
+                takeProfitPrice: convertToPrecision(takeProfitPrice, priceScale).toString(),
+                stopLossType: 0,
+                takeProfitType: 0,
+                stopLossOrderPrice: convertToPrecision(stoplossPrice, priceScale).toString(),
+                takeProfitOrderPrice: convertToPrecision(takeProfitPrice, priceScale).toString(),
+            });
+            console.log('TP/SL placed via stoporder');
+        } catch (error) {
+            console.error('Failed to place TP/SL:', error);
+        }
+    }
+
+    return {
+        success: true,
+        entry: entryPrice,
+        stoploss: stoplossPrice,
+        takeprofit: takeProfitPrice,
+        qty,
+    };
 };
 
 const setStoploss = async ({
-  symbol,
-  price,
-  side,
-  client,
+    symbol,
+    price,
+    side: _side,
+    client,
 }: {
-  symbol: string;
-  price: number;
-  side: 'BUY' | 'SELL';
-  client: MexcClient;
+    symbol: string;
+    price: number;
+    side: 'BUY' | 'SELL';
+    client: MexcClient;
 }) => {
-  const contractInfo = await getContractInfo(client, symbol);
-  const { priceScale } = contractInfo;
+    const contractInfo = await getContractInfo(client, symbol);
+    const { priceScale } = contractInfo;
 
-  // Get current position
-  const positionSide = side === 'BUY' ? 1 : 2;
-  const positions = await currentPositions(client, symbol);
-  const currentPosition = positions.find((p) => p.type === positionSide);
+    const positions = await currentPositions(client, symbol);
+    const currentPosition = positions[0];
 
-  if (!currentPosition) throw new Error('currentPosition is undefined.');
+    if (!currentPosition) throw new Error('currentPosition is undefined.');
 
-  const currentQty = parseFloat(currentPosition.holdVolume.toString());
-
-  // Cancel existing stop orders for this symbol
-  try {
-    const openOrders = await client.get<MexcOrder[]>('/api/v1/private/order/list/open_orders', { symbol });
-    const stopOrders = openOrders.filter((o) => o.type === 3); // type 3 = stop
-
-    for (const order of stopOrders) {
-      try {
-        await client.delete(`/api/v1/private/order/cancel`, { orderId: order.id });
-      } catch (e) {
-        console.error('Failed to cancel stop order:', e);
-      }
+    // Get existing TP price to preserve it
+    let existingTP = '';
+    try {
+        const stopOrders = await getStopOrders(client, symbol);
+        const existing = stopOrders.find(
+            (o) => String(o.positionId) === String(currentPosition.positionId),
+        );
+        if (existing?.takeProfitPrice) {
+            existingTP = existing.takeProfitPrice.toString();
+        }
+    } catch (e) {
+        console.error('Failed to fetch existing stop orders:', e);
     }
-  } catch (e) {
-    console.error('Failed to fetch open orders for SL cancel:', e);
-  }
 
-  // Place new stop-loss order
-  try {
-    const executedStopLossOrder = await client.post<MexcOrder>('/api/v1/private/order/stop_order', {
-      symbol,
-      price: convertToPrecision(price, priceScale).toString(),
-      vol: currentQty.toString(),
-      side: mapCloseSide(side),
-      type: 3, // stop
-      triggerPrice: convertToPrecision(price, priceScale).toString(),
-      triggerType: 1,
-      executeCycle: 1,
-      executeDirection: side === 'BUY' ? 2 : 1,
-    });
+    // Cancel existing TP/SL orders for this position
+    try {
+        await client.post('/api/v1/private/stoporder/cancel_all', { positionId: currentPosition.positionId });
+    } catch (e) {
+        console.error('Failed to cancel existing stop orders:', e);
+    }
 
-    console.log('MOVE STOPLOSS');
-    console.log({ executedStopLossOrder });
-    console.log('--------');
-  } catch (error) {
-    console.error(error);
-  }
+    // Place new SL with preserved TP
+    try {
+        const params: Record<string, any> = {
+            positionId: currentPosition.positionId,
+            vol: currentPosition.holdVol,
+            lossTrend: 1,
+            profitTrend: 1,
+            stopLossPrice: convertToPrecision(price, priceScale).toString(),
+            stopLossType: 0,
+            stopLossOrderPrice: convertToPrecision(price, priceScale).toString(),
+        };
+
+        if (existingTP) {
+            params.takeProfitPrice = convertToPrecision(parseFloat(existingTP), priceScale).toString();
+            params.takeProfitType = 0;
+            params.takeProfitOrderPrice = convertToPrecision(parseFloat(existingTP), priceScale).toString();
+        }
+
+        await client.post('/api/v1/private/stoporder/place', params);
+
+        console.log('MOVE STOPLOSS to', price, 'TP preserved:', existingTP || 'none');
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
 };
 
 const getPosition = async (symbol: string, client: MexcClient) => {
-  const positions = await currentPositions(client, symbol);
-  return positions[0] || undefined;
+    const positions = await currentPositions(client, symbol);
+    return positions[0] || undefined;
 };
 
+interface MexcHistoryOrder {
+    orderId: string;
+    symbol: string;
+    price: number;
+    vol: number;
+    dealVol: number;
+    dealAvgPrice: number;
+    side: number;
+    orderType: number;
+    openType: number;
+    leverage: number;
+    profit: number;
+    fee: number;
+    status: number;
+    createTime: number;
+    updateTime: number;
+    [key: string]: any;
+}
+
 const getTradeHistory = async (
-  client: MexcClient,
-  symbol: string,
-  limit: number,
-  startTime?: number,
-  endTime?: number,
+    client: MexcClient,
+    symbol: string,
+    limit: number,
+    startTime?: number,
+    endTime?: number,
 ) => {
-  if (!startTime) startTime = moment().subtract(7, 'day').unix() * 1000;
-  if (!endTime) endTime = moment().unix() * 1000;
+    if (!startTime) startTime = moment().subtract(7, 'day').unix() * 1000;
+    if (!endTime) endTime = moment().unix() * 1000;
 
-  const result = await client.get<MexcHistoryOrder[]>('/api/v1/private/order/list/history_orders', {
-    symbol,
-    page_num: 1,
-    page_size: limit,
-    ...(startTime && { start_time: startTime }),
-    ...(endTime && { end_time: endTime }),
-  });
+    const result = await client.get<MexcHistoryOrder[]>('/api/v1/private/order/list/history_orders', {
+        symbol,
+        page_num: 1,
+        page_size: Math.min(limit, 100),
+        start_time: startTime,
+        end_time: endTime,
+    });
 
-  return result;
+    return result;
 };
 
 const getIncome = async (
-  client: MexcClient,
-  options?: {
-    symbol?: string;
-    startTime?: number;
-    endTime?: number;
-    limit?: number;
-  },
-  cacheId?: string,
+    client: MexcClient,
+    options?: {
+        symbol?: string;
+        startTime?: number;
+        endTime?: number;
+        limit?: number;
+    },
+    cacheId?: string,
 ) => {
-  const startTime = options?.startTime || moment().endOf('day').subtract(3, 'month').unix() * 1000;
-  const endTime = options?.endTime || moment().endOf('day').unix() * 1000;
+    const startTime = options?.startTime || moment().endOf('day').subtract(3, 'month').unix() * 1000;
+    const endTime = options?.endTime || moment().endOf('day').unix() * 1000;
 
-  const cacheKey = [
-    cacheId || 'mexc',
-    'income',
-    options?.symbol || 'all',
-    startTime,
-    endTime,
-  ].join('-');
+    const cacheKey = [
+        cacheId || 'mexc',
+        'income',
+        options?.symbol || 'all',
+        startTime,
+        endTime,
+    ].join('-');
 
-  const cachedData = cache.get(cacheKey);
-  if (cachedData) return cachedData;
+    const cachedData = cache.get(cacheKey);
+    if (cachedData) return cachedData;
 
-  const result = await client.get<MexcHistoryPosition[]>('/api/v1/private/position/history_positions', {
-    ...(options?.symbol && { symbol: options.symbol }),
-    start_time: startTime,
-    end_time: endTime,
-    page_num: 1,
-    page_size: options?.limit || 100,
-  });
+    const result = await client.get<MexcHistoryPosition[]>('/api/v1/private/position/list/history_positions', {
+        ...(options?.symbol && { symbol: options.symbol }),
+        start_time: startTime,
+        end_time: endTime,
+        page_num: 1,
+        page_size: options?.limit || 100,
+    });
 
-  cache.set(cacheKey, result, 60 * 5);
-  return result;
+    cache.set(cacheKey, result, 60 * 5);
+    return result;
 };
 
 const getOpenOrders = async (client: MexcClient, symbol?: string) => {
-  const params: Record<string, any> = {};
-  if (symbol) params.symbol = symbol;
+    const params: Record<string, any> = {};
+    if (symbol) params.symbol = symbol;
 
-  const orders = await client.get<MexcOrder[]>('/api/v1/private/order/list/open_orders', params);
-  return orders;
+    const orders = await client.get<MexcOrder[]>('/api/v1/private/order/list/open_orders', params);
+    return orders;
+};
+
+interface MexcStopOrder {
+    stopPlanOrderId: number;
+    positionId: number;
+    symbol: string;
+    stopLossPrice: number;
+    takeProfitPrice: number;
+    vol: number;
+    [key: string]: any;
+}
+
+const getStopOrders = async (client: MexcClient, symbol?: string): Promise<MexcStopOrder[]> => {
+    const params: Record<string, any> = { page_num: 1, page_size: 100, is_finished: 0 };
+    if (symbol) params.symbol = symbol;
+
+    const orders = await client.get<MexcStopOrder[]>('/api/v1/private/stoporder/list/orders', params);
+    return orders;
 };
 
 const MexcFunctions = {
-  checkConnection,
-  currentPositions,
-  entry,
-  getPosition,
-  setStoploss,
-  getCurrentBalance,
-  getCurrentBalanceV3,
-  getTradeHistory,
-  getOpenOrders,
-  getIncome,
-  loadMexcClient,
-  getContractInfo,
+    checkConnection,
+    currentPositions,
+    entry,
+    getPosition,
+    setStoploss,
+    getCurrentBalance,
+    getCurrentBalanceV3,
+    getTradeHistory,
+    getOpenOrders,
+    getStopOrders,
+    getIncome,
+    loadMexcClient,
+    getContractInfo,
 };
 
 export default MexcFunctions;

--- a/src/services/mexc/client.ts
+++ b/src/services/mexc/client.ts
@@ -2,238 +2,236 @@ import axios, { AxiosInstance } from 'axios';
 import crypto from 'crypto';
 
 export interface MexcResponse<T> {
-  success: boolean;
-  code: number;
-  data: T;
-  message?: string;
+    success: boolean;
+    code: number;
+    data: T;
+    message?: string;
 }
 
 export interface MexcPosition {
-  id: string;
-  positionId: number;
-  symbol: string;
-  type: number; // 1=long, 2=short
-  openType: number; // 1=cross, 2=isolated
-  volume: number;
-  holdVolume: number;
-  frozenVolume: number;
-  closeVolume: number;
-  averageOpenPrice: string;
-  averageOpenPriceUsd: string;
-  closeAveragePrice: string;
-  closeAveragePriceUsd: string;
-  leverage: number;
-  holdFee: string;
-  holdFeeRate: string;
-  stopLossPrice: string;
-  takeProfitPrice: string;
-  period: number;
-  realizeProfit: string;
-  realizeProfitUsd: string;
-  unrealizedProfit: string;
-  unrealizedProfitUsd: string;
-  positionMargin: string;
-  initialMargin: string;
-  initialMarginUsd: string;
-  maintainMargin: string;
-  liquidatePrice: string;
-  liquidateRate: string;
-  createTime: number;
-  updateTime: number;
+    positionId: number;
+    symbol: string;
+    positionType: number; // 1=long, 2=short
+    openType: number; // 1=isolated, 2=cross
+    state: number; // 1=holding, 2=system-held, 3=closed
+    holdVol: number;
+    frozenVol: number;
+    closeVol: number;
+    holdAvgPrice: number;
+    holdAvgPriceFullyScale: string;
+    openAvgPrice: number;
+    openAvgPriceFullyScale: string;
+    closeAvgPrice: number;
+    liquidatePrice: number;
+    oim: number;
+    im: number;
+    holdFee: number;
+    realised: number;
+    leverage: number;
+    marginRatio: number;
+    autoAddIm: boolean;
+    profitRatio: number;
+    newOpenAvgPrice: number;
+    newCloseAvgPrice: number;
+    closeProfitLoss: number;
+    fee: number;
+    totalFee: number;
+    createTime: number;
+    updateTime: number;
+    [key: string]: any;
 }
 
 export interface MexcBalance {
-  currency: string;
-  positionEquity: string;
-  frozenBalance: string;
-  availableBalance: string;
-  cashBalance: string;
-  unrealized: string;
-  maxTransferable: string;
-  equity: string;
-  bonus: string;
-  crossUnrealized: string;
-  isolatedUnrealized: string;
-  longTotalUnrealized: string;
-  shortTotalUnrealized: string;
-  longTotalPosition: string;
-  shortTotalPosition: string;
-  totalPoint: string;
-  availablePoint: string;
-  frozenPoint: string;
-  cumRealizedPnl: string;
-  dailyRealizedPnl: string;
+    currency: string;
+    positionMargin: number;
+    frozenBalance: number;
+    availableBalance: number;
+    cashBalance: number;
+    equity: number;
+    unrealized: number;
+    bonus: number;
+    bonusExpireTime?: number;
+    availableCash: number;
+    availableOpen: number;
+    debtAmount: number;
+    contributeMarginAmount: number;
+    vcoinId: string;
+    [key: string]: any;
 }
 
 export interface MexcOrder {
-  id: string;
-  symbol: string;
-  type: number; // 1=market, 2=limit, 3=stop, 5=take_profit
-  price: string;
-  vol: string;
-  leverage: number;
-  dealVol: string;
-  openType: number;
-  side: number; // 1=open_long, 2=close_long, 3=open_short, 4=close_short
-  triggerPrice: string;
-  triggerType: number;
-  status: number;
-  stopLossPrice: string;
-  takeProfitPrice: string;
-  triggerSource: number;
-  outerId: string;
-  createTime: number;
-  updateTime: number;
+    orderId: string;
+    symbol: string;
+    positionId: number;
+    price: number;
+    priceStr: string;
+    vol: number;
+    leverage: number;
+    side: number; // 1=open_long, 2=close_short, 3=open_short, 4=close_long
+    category: number;
+    orderType: number; // 1=limit, 2=post_only, 3=IOC, 4=FOK, 5=market
+    dealAvgPrice: number;
+    dealAvgPriceStr: string;
+    dealVol: number;
+    orderMargin: number;
+    takerFee: number;
+    makerFee: number;
+    profit: number;
+    fee: number;
+    triggerPrice?: number;
+    triggerType?: number;
+    status: number;
+    stopLossPrice?: number;
+    takeProfitPrice?: number;
+    triggerSource?: number;
+    externalOid?: string;
+    createTime: number;
+    updateTime: number;
+    [key: string]: any;
 }
 
 export interface MexcContractInfo {
-  symbol: string;
-  displayName: string;
-  baseCoin: string;
-  quoteCoin: string;
-  settlementCoin: string;
-  contractSize: string;
-  minVol: string;
-  maxVol: string;
-  priceUnit: string;
-  volUnit: string;
-  leverageMin: number;
-  leverageMax: number;
-  priceScale: number;
-  volScale: number;
-  valueScale: number;
-  maxHoldVol: string;
-  maintenanceRatio: string;
-  initialMargin: string;
-  riskLimitBase: string;
-  riskLimitStep: string;
-  maxPosition: string;
-  fundingInterval: number;
-  status: string;
-}
-
-export interface MexcHistoryOrder {
-  id: string;
-  symbol: string;
-  type: number;
-  price: string;
-  vol: string;
-  dealVol: string;
-  openType: number;
-  side: number;
-  profit: string;
-  fee: string;
-  triggerPrice: string;
-  triggerType: number;
-  triggerSource: number;
-  status: number;
-  stopLossPrice: string;
-  takeProfitPrice: string;
-  outerId: string;
-  createTime: number;
-  updateTime: number;
+    symbol: string;
+    displayName: string;
+    baseCoin: string;
+    quoteCoin: string;
+    settlementCoin: string;
+    contractSize: string;
+    minVol: string;
+    maxVol: string;
+    priceUnit: string;
+    volUnit: string;
+    leverageMin: number;
+    leverageMax: number;
+    priceScale: number;
+    volScale: number;
+    valueScale: number;
+    maxHoldVol: string;
+    maintenanceRatio: string;
+    initialMargin: string;
+    riskLimitBase: string;
+    riskLimitStep: string;
+    maxPosition: string;
+    fundingInterval: number;
+    status: string;
+    [key: string]: any;
 }
 
 export interface MexcHistoryPosition {
-  id: string;
-  positionId: number;
-  symbol: string;
-  type: number;
-  openType: number;
-  holdVolume: number;
-  closeVolume: number;
-  averageOpenPrice: string;
-  closeAveragePrice: string;
-  leverage: number;
-  realizeProfit: string;
-  realizeProfitUsd: string;
-  stopLossPrice: string;
-  takeProfitPrice: string;
-  triggerSource: number;
-  createTime: number;
-  updateTime: number;
+    positionId: number;
+    symbol: string;
+    positionType: number;
+    openType: number;
+    state: number;
+    holdVol: number;
+    frozenVol: number;
+    closeVol: number;
+    holdAvgPrice: number;
+    holdAvgPriceFullyScale: string;
+    openAvgPrice: number;
+    openAvgPriceFullyScale: string;
+    closeAvgPrice: number;
+    liquidatePrice: number;
+    oim: number;
+    im: number;
+    holdFee: number;
+    realised: number;
+    leverage: number;
+    profitRatio: number;
+    newOpenAvgPrice: number;
+    newCloseAvgPrice: number;
+    closeProfitLoss: number;
+    fee: number;
+    totalFee: number;
+    createTime: number;
+    updateTime: number;
+    [key: string]: any;
 }
 
 export class MexcClient {
-  private apiKey: string;
-  private secretKey: string;
-  private baseUrl: string;
-  private axiosInstance: AxiosInstance;
+    private apiKey: string;
+    private secretKey: string;
+    private baseUrl: string;
+    private axiosInstance: AxiosInstance;
 
-  constructor(apiKey: string, secretKey: string, testnet?: boolean) {
-    this.apiKey = apiKey;
-    this.secretKey = secretKey;
-    this.baseUrl = testnet ? 'https://contract.mexc.com' : 'https://contract.mexc.com';
+    constructor(apiKey: string, secretKey: string) {
+        this.apiKey = apiKey;
+        this.secretKey = secretKey;
+        this.baseUrl = 'https://api.mexc.com';
 
-    this.axiosInstance = axios.create({
-      baseURL: this.baseUrl,
-      timeout: 10000,
-    });
-  }
-
-  private sign(params: string, timestamp: string): string {
-    const message = this.apiKey + timestamp + params;
-    return crypto.createHmac('sha256', this.secretKey).update(message).digest('hex');
-  }
-
-  private buildHeaders(params: string): Record<string, string> {
-    const timestamp = Date.now().toString();
-    const signature = this.sign(params, timestamp);
-
-    return {
-      'ApiKey': this.apiKey,
-      'Request-Time': timestamp,
-      'Signature': signature,
-      'Recv-Window': '5000',
-      'Content-Type': 'application/json',
-    };
-  }
-
-  private static sortParams(params: Record<string, any>): string {
-    return Object.keys(params)
-      .sort()
-      .map((key) => `${key}=${params[key]}`)
-      .join('&');
-  }
-
-  public async get<T>(path: string, params?: Record<string, any>): Promise<T> {
-    const queryString = params ? MexcClient.sortParams(params) : '';
-    const headers = this.buildHeaders(queryString);
-    const url = params ? `${path}?${queryString}` : path;
-
-    const response = await this.axiosInstance.get<MexcResponse<T>>(url, { headers });
-
-    if (!response.data.success) {
-      throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+        this.axiosInstance = axios.create({
+            baseURL: this.baseUrl,
+            timeout: 10000,
+        });
     }
 
-    return response.data.data;
-  }
-
-  public async post<T>(path: string, body: Record<string, any>): Promise<T> {
-    const bodyString = JSON.stringify(body);
-    const headers = this.buildHeaders(bodyString);
-
-    const response = await this.axiosInstance.post<MexcResponse<T>>(path, body, { headers });
-
-    if (!response.data.success) {
-      throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+    private sign(params: string, timestamp: string): string {
+        const message = this.apiKey + timestamp + params;
+        return crypto.createHmac('sha256', this.secretKey).update(message).digest('hex');
     }
 
-    return response.data.data;
-  }
+    private buildHeaders(params: string): Record<string, string> {
+        const timestamp = Date.now().toString();
+        const signature = this.sign(params, timestamp);
 
-  public async delete<T>(path: string, params?: Record<string, any>): Promise<T> {
-    const queryString = params ? MexcClient.sortParams(params) : '';
-    const headers = this.buildHeaders(queryString);
-    const url = params ? `${path}?${queryString}` : path;
-
-    const response = await this.axiosInstance.delete<MexcResponse<T>>(url, { headers });
-
-    if (!response.data.success) {
-      throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+        return {
+            'ApiKey': this.apiKey,
+            'Request-Time': timestamp,
+            'Signature': signature,
+            'Recv-Window': '5000',
+            'Content-Type': 'application/json',
+        };
     }
 
-    return response.data.data;
-  }
+    private static sortParams(params: Record<string, any>): string {
+        return Object.keys(params)
+            .filter(key => params[key] !== null && params[key] !== undefined)
+            .sort()
+            .map((key) => `${key}=${params[key]}`)
+            .join('&');
+    }
+
+    public async get<T>(path: string, params?: Record<string, any>): Promise<T> {
+        const filteredParams = params
+            ? Object.fromEntries(Object.entries(params).filter(([_, v]) => v !== null && v !== undefined))
+            : undefined;
+        const queryString = filteredParams ? MexcClient.sortParams(filteredParams) : '';
+        const headers = this.buildHeaders(queryString);
+        const url = filteredParams ? `${path}?${queryString}` : path;
+
+        const response = await this.axiosInstance.get<MexcResponse<T>>(url, { headers });
+
+        if (!response.data.success) {
+            throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+        }
+
+        return response.data.data;
+    }
+
+    public async post<T>(path: string, body: Record<string, any>): Promise<T> {
+        const bodyString = JSON.stringify(body);
+        const headers = this.buildHeaders(bodyString);
+
+        const response = await this.axiosInstance.post<MexcResponse<T>>(path, body, { headers });
+
+        if (!response.data.success) {
+            throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+        }
+
+        return response.data.data;
+    }
+
+    public async delete<T>(path: string, params?: Record<string, any>): Promise<T> {
+        const queryString = params ? MexcClient.sortParams(params) : '';
+        const headers = this.buildHeaders(queryString);
+        const url = params ? `${path}?${queryString}` : path;
+
+        const response = await this.axiosInstance.delete<MexcResponse<T>>(url, { headers });
+
+        if (!response.data.success) {
+            throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+        }
+
+        return response.data.data;
+    }
 }

--- a/src/services/mexc/client.ts
+++ b/src/services/mexc/client.ts
@@ -1,0 +1,239 @@
+import axios, { AxiosInstance } from 'axios';
+import crypto from 'crypto';
+
+export interface MexcResponse<T> {
+  success: boolean;
+  code: number;
+  data: T;
+  message?: string;
+}
+
+export interface MexcPosition {
+  id: string;
+  positionId: number;
+  symbol: string;
+  type: number; // 1=long, 2=short
+  openType: number; // 1=cross, 2=isolated
+  volume: number;
+  holdVolume: number;
+  frozenVolume: number;
+  closeVolume: number;
+  averageOpenPrice: string;
+  averageOpenPriceUsd: string;
+  closeAveragePrice: string;
+  closeAveragePriceUsd: string;
+  leverage: number;
+  holdFee: string;
+  holdFeeRate: string;
+  stopLossPrice: string;
+  takeProfitPrice: string;
+  period: number;
+  realizeProfit: string;
+  realizeProfitUsd: string;
+  unrealizedProfit: string;
+  unrealizedProfitUsd: string;
+  positionMargin: string;
+  initialMargin: string;
+  initialMarginUsd: string;
+  maintainMargin: string;
+  liquidatePrice: string;
+  liquidateRate: string;
+  createTime: number;
+  updateTime: number;
+}
+
+export interface MexcBalance {
+  currency: string;
+  positionEquity: string;
+  frozenBalance: string;
+  availableBalance: string;
+  cashBalance: string;
+  unrealized: string;
+  maxTransferable: string;
+  equity: string;
+  bonus: string;
+  crossUnrealized: string;
+  isolatedUnrealized: string;
+  longTotalUnrealized: string;
+  shortTotalUnrealized: string;
+  longTotalPosition: string;
+  shortTotalPosition: string;
+  totalPoint: string;
+  availablePoint: string;
+  frozenPoint: string;
+  cumRealizedPnl: string;
+  dailyRealizedPnl: string;
+}
+
+export interface MexcOrder {
+  id: string;
+  symbol: string;
+  type: number; // 1=market, 2=limit, 3=stop, 5=take_profit
+  price: string;
+  vol: string;
+  leverage: number;
+  dealVol: string;
+  openType: number;
+  side: number; // 1=open_long, 2=close_long, 3=open_short, 4=close_short
+  triggerPrice: string;
+  triggerType: number;
+  status: number;
+  stopLossPrice: string;
+  takeProfitPrice: string;
+  triggerSource: number;
+  outerId: string;
+  createTime: number;
+  updateTime: number;
+}
+
+export interface MexcContractInfo {
+  symbol: string;
+  displayName: string;
+  baseCoin: string;
+  quoteCoin: string;
+  settlementCoin: string;
+  contractSize: string;
+  minVol: string;
+  maxVol: string;
+  priceUnit: string;
+  volUnit: string;
+  leverageMin: number;
+  leverageMax: number;
+  priceScale: number;
+  volScale: number;
+  valueScale: number;
+  maxHoldVol: string;
+  maintenanceRatio: string;
+  initialMargin: string;
+  riskLimitBase: string;
+  riskLimitStep: string;
+  maxPosition: string;
+  fundingInterval: number;
+  status: string;
+}
+
+export interface MexcHistoryOrder {
+  id: string;
+  symbol: string;
+  type: number;
+  price: string;
+  vol: string;
+  dealVol: string;
+  openType: number;
+  side: number;
+  profit: string;
+  fee: string;
+  triggerPrice: string;
+  triggerType: number;
+  triggerSource: number;
+  status: number;
+  stopLossPrice: string;
+  takeProfitPrice: string;
+  outerId: string;
+  createTime: number;
+  updateTime: number;
+}
+
+export interface MexcHistoryPosition {
+  id: string;
+  positionId: number;
+  symbol: string;
+  type: number;
+  openType: number;
+  holdVolume: number;
+  closeVolume: number;
+  averageOpenPrice: string;
+  closeAveragePrice: string;
+  leverage: number;
+  realizeProfit: string;
+  realizeProfitUsd: string;
+  stopLossPrice: string;
+  takeProfitPrice: string;
+  triggerSource: number;
+  createTime: number;
+  updateTime: number;
+}
+
+export class MexcClient {
+  private apiKey: string;
+  private secretKey: string;
+  private baseUrl: string;
+  private axiosInstance: AxiosInstance;
+
+  constructor(apiKey: string, secretKey: string, testnet?: boolean) {
+    this.apiKey = apiKey;
+    this.secretKey = secretKey;
+    this.baseUrl = testnet ? 'https://contract.mexc.com' : 'https://contract.mexc.com';
+
+    this.axiosInstance = axios.create({
+      baseURL: this.baseUrl,
+      timeout: 10000,
+    });
+  }
+
+  private sign(params: string, timestamp: string): string {
+    const message = this.apiKey + timestamp + params;
+    return crypto.createHmac('sha256', this.secretKey).update(message).digest('hex');
+  }
+
+  private buildHeaders(params: string): Record<string, string> {
+    const timestamp = Date.now().toString();
+    const signature = this.sign(params, timestamp);
+
+    return {
+      'ApiKey': this.apiKey,
+      'Request-Time': timestamp,
+      'Signature': signature,
+      'Recv-Window': '5000',
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private static sortParams(params: Record<string, any>): string {
+    return Object.keys(params)
+      .sort()
+      .map((key) => `${key}=${params[key]}`)
+      .join('&');
+  }
+
+  public async get<T>(path: string, params?: Record<string, any>): Promise<T> {
+    const queryString = params ? MexcClient.sortParams(params) : '';
+    const headers = this.buildHeaders(queryString);
+    const url = params ? `${path}?${queryString}` : path;
+
+    const response = await this.axiosInstance.get<MexcResponse<T>>(url, { headers });
+
+    if (!response.data.success) {
+      throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+    }
+
+    return response.data.data;
+  }
+
+  public async post<T>(path: string, body: Record<string, any>): Promise<T> {
+    const bodyString = JSON.stringify(body);
+    const headers = this.buildHeaders(bodyString);
+
+    const response = await this.axiosInstance.post<MexcResponse<T>>(path, body, { headers });
+
+    if (!response.data.success) {
+      throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+    }
+
+    return response.data.data;
+  }
+
+  public async delete<T>(path: string, params?: Record<string, any>): Promise<T> {
+    const queryString = params ? MexcClient.sortParams(params) : '';
+    const headers = this.buildHeaders(queryString);
+    const url = params ? `${path}?${queryString}` : path;
+
+    const response = await this.axiosInstance.delete<MexcResponse<T>>(url, { headers });
+
+    if (!response.data.success) {
+      throw new Error(`MEXC API error: ${response.data.message || response.data.code}`);
+    }
+
+    return response.data.data;
+  }
+}


### PR DESCRIPTION
## MEXC Futures API Integration

### Changes
- **Prisma**: Added `MEXC` to Provider enum with migration
- **Client**: Custom MEXC HTTP client (`src/services/mexc/client.ts`) with HMAC-SHA256 signing, typed interfaces for all MEXC response types
- **Service**: Full futures trading service (`src/services/mexc.ts`) mirroring Binance pattern:
  - `loadMexcClient()` - per-user encrypted API key loading
  - `entry()` - market entry with leverage, SL/TP orders
  - `setStoploss()` - move stop loss (cancel old, place new)
  - `currentPositions()`, `getCurrentBalance()`, `getTradeHistory()`, `getIncome()`, `getOpenOrders()`
- **Controller**: `MexcController` with same endpoint structure as Binance
- **Routes**: Registered at `/mexc` with `apiKeyMiddleware`

### Endpoints
```
POST /api/v1/mexc/entry/:trade_account_id
GET  /api/v1/mexc/balance/:trade_account_id
GET  /api/v1/mexc/balance-v3/:trade_account_id
GET  /api/v1/mexc/current-position/:trade_account_id
GET  /api/v1/mexc/open-orders/:trade_account_id
GET  /api/v1/mecx/trade-history/:trade_account_id
GET  /api/v1/mexc/income/:trade_account_id
```

### Symbol Normalization
Auto-converts `BTCUSDT` -> `BTC_USDT` for MEXC compatibility

### Files
| Status | File |
|--------|------|
| NEW | `src/services/mexc/client.ts` |
| NEW | `src/services/mexc.ts` |
| NEW | `src/controllers/MexcController.ts` |
| MOD | `prisma/schema.prisma` |
| MOD | `src/routes/index.ts` |
| NEW | `prisma/migrations/20260409103856_add_mexc_provider/migration.sql` |